### PR TITLE
Fix empty list handling in minidsp custom descriptor

### DIFF
--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -372,7 +372,7 @@ def make_peq_layout(cfg: dict) -> MinidspDescriptor:
                 raise ValueError(f"Custom PeqRoutes is missing keys - {missing_keys} - from {r}")
 
             def to_ints(v):
-                return [int(i) for i in v] if v else None
+                return [int(i) for i in v] if v else []
 
             return PeqRoutes(r['name'], int(r['biquads']), to_ints(r['channels']), to_ints(r['slots']),
                              to_ints(r.get('groups', None)))


### PR DESCRIPTION
Possible fix for #63 (more details mentioned in the issue). Seems to work for me. With this BEQ gets applied on Input 1 only of miniDSP 2x4HD with mentioned custom descriptor. Tested in WSL (do not know how to compile/test on Windows where I really need the fix).

So for empty slots/channels list it should be okay as some miniDSP descriptors internally set that only. But I'm not really sure about usage of groups and if it affects that. Earlier it was getting `None` most of the time for `groups` but now it will be empty list `[]`.