### PR TITLE
Fix type error on HTP-1 sleep

### DIFF
--- a/ezbeq/htp1.py
+++ b/ezbeq/htp1.py
@@ -252,7 +252,10 @@ class Htp1Protocol(WebSocketClientProtocol):
                 self.factory.listener.on_mso(json.loads(msg[4:]))
             elif msg.startswith('msoupdate '):
                 logger.debug(f"Processing msoupdate {msg}")
-                self.factory.listener.on_msoupdate(json.loads(msg[10:]))
+                msoupdate = json.loads(msg[10:])
+                if isinstance(msoupdate, dict):
+                    msoupdate = [msoupdate]
+                self.factory.listener.on_msoupdate(msoupdate)
             else:
                 logger.info(f"Received unknown payload {msg}")
 


### PR DESCRIPTION
This fixes a `<class 'TypeError'>: string indices must be integers, not 'str'` error and accompanying stack trace I was seeing every time I would put my HTP-1 to sleep.

From debug logs:

```
2025-06-15 17:26:22,543 - 1 - MainThread - ezbeq.htp1 - DEBUG - onMessage - Processing msoupdate msoupdate {"op":"replace","path":"/volume","value":-40}
2025-06-15 17:26:22,547 - 1 - MainThread - ezbeq.htp1 - WARNING - onClose - UNCLEAN! Disconnected code: 1006 reason: connection was closed uncleanly ("peer dropped the TCP connection without previous WebSocket closing handshake")
2025-06-15 17:26:22,547 - 1 - MainThread - ezbeq.htp1 - WARNING - clientConnectionLost - Client connection failed [Failure instance: Traceback: <class 'TypeError'>: string indices must be integers, not 'str'
/opt/venv/lib/python3.11/site-packages/twisted/internet/posixbase.py:491:_doReadOrWrite
/opt/venv/lib/python3.11/site-packages/twisted/internet/tcp.py:250:doRead
/opt/venv/lib/python3.11/site-packages/twisted/internet/tcp.py:255:_dataReceived
/opt/venv/lib/python3.11/site-packages/autobahn/twisted/websocket.py:348:dataReceived
/opt/venv/lib/python3.11/site-packages/autobahn/websocket/protocol.py:1243:_dataReceived
/opt/venv/lib/python3.11/site-packages/autobahn/websocket/protocol.py:1255:consumeData
/opt/venv/lib/python3.11/site-packages/autobahn/websocket/protocol.py:1619:processData
/opt/venv/lib/python3.11/site-packages/autobahn/websocket/protocol.py:1747:onFrameEnd
/opt/venv/lib/python3.11/site-packages/autobahn/twisted/websocket.py:384:_onMessageEnd
/opt/venv/lib/python3.11/site-packages/autobahn/websocket/protocol.py:647:onMessageEnd
/opt/venv/lib/python3.11/site-packages/autobahn/twisted/websocket.py:387:_onMessage
/opt/venv/lib/python3.11/site-packages/ezbeq/htp1.py:255:onMessage
/opt/venv/lib/python3.11/site-packages/ezbeq/htp1.py:191:on_msoupdate
] .. retrying ..
```

I think this is due to having my "Power on Volume" set to -40, so it's setting it on any form of shutdown.

After this change the debug logs look like:

```
2025-06-15 14:10:29,187 - 31098 - MainThread - ezbeq.htp1 - DEBUG - onMessage - Processing msoupdate msoupdate [{"op":"replace","path":"/volume","value":-40}]
2025-06-15 14:10:29,187 - 31098 - MainThread - ezbeq.htp1 - DEBUG - on_msoupdate - Ignoring {'op': 'replace', 'path': '/volume', 'value': -40}
```