### PR TITLE
fix: atomic state file writes in PersistentDevice._persist()

### DIFF
--- a/ezbeq/device.py
+++ b/ezbeq/device.py
@@ -248,8 +248,10 @@ class PersistentDevice(Device, ABC, Generic[T]):
 
     def _persist(self):
         assert self._current_state, 'hydrate cannot return None'
-        with open(self.__file_name, 'w') as f:
+        tmp = self.__file_name + '.tmp'
+        with open(tmp, 'w') as f:
             json.dump(self._current_state.serialise(), f, sort_keys=True)
+        os.replace(tmp, self.__file_name)
 
     def _broadcast(self):
         if self.ws_server:

--- a/tests/test_minidsp_api.py
+++ b/tests/test_minidsp_api.py
@@ -2216,6 +2216,25 @@ def test_reload_from_cache(minidsp_client, tmp_path):
             verify_slot(s, idx + 1)
 
 
+def test_persist_is_atomic(minidsp_client, minidsp_app):
+    '''_persist() must write via a temp file and os.replace() so readers never see a partial write.'''
+    config: MinidspSpyConfig = minidsp_app.config['APP_CONFIG']
+    state_file = os.path.join(config.config_path, 'master.json')
+    tmp_file = state_file + '.tmp'
+
+    # trigger a state-mutating operation so _persist() is called
+    r = minidsp_client.put('/api/1/devices/master/config/1/active')
+    assert r.status_code == 200
+
+    # the .tmp scratch file must not linger after _persist() completes
+    assert not os.path.exists(tmp_file), '.tmp file was not cleaned up — os.replace() may not have been called'
+    # the real state file must exist and contain valid JSON
+    assert os.path.exists(state_file), 'state file is missing after persist'
+    with open(state_file) as f:
+        data = json.load(f)
+    assert data is not None
+
+
 @pytest.mark.parametrize("outputs",
                          [[], [1], [2], [3], [4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4], [1, 2, 3], [1, 2, 4],
                           [1, 3, 4], [2, 3, 4], [1, 2, 3, 4]], ids=str)


### PR DESCRIPTION
## Summary

- Fixes a race condition where concurrent device commands could corrupt the state file
- `_persist()` now writes JSON to a `.tmp` file then uses `os.replace()` for an atomic swap
- Adds `test_persist_is_atomic` to verify no `.tmp` remnant is left behind after a normal write

## Test plan

- [ ] Run `pytest tests/test_minidsp_api.py` — new test `test_persist_is_atomic` should pass
- [ ] Verify existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)