### PR TITLE
Fix BEQ application on HTx by targeting input PEQ

### DIFF
--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -330,16 +330,17 @@ class MinidspDDRC24(MinidspDescriptor):
 
 class MinidspHTX(MinidspDescriptor):
 
-    def __init__(self, slot_names: dict[str, str] = None, sw_channels: list[int] = None):
-        c = sw_channels if sw_channels is not None else [3]
+    def __init__(self, slot_names: dict[str, str] = None, input_channels: list[int] = None):
+        c = input_channels if input_channels is not None else [0]
         if any(ch for ch in c if ch < 0 or ch > 7):
             raise ValueError(f"Invalid channels {c} must be between 0 and 7")
         non_sw = [c1 for c1 in zero_til(8) if c1 not in c]
         super().__init__('HTX',
                          '48000',
+			 i=PeqRoutes(INPUT_NAME, 10, c, zero_til(10)),
                          xo=PeqRoutes(CROSSOVER_NAME, 8, zero_til(8), [], zero_til(2)),
-                         o=PeqRoutes(OUTPUT_NAME, 10, c, zero_til(10)),
-                         extra=[PeqRoutes(OUTPUT_NAME, 10, non_sw, []) if non_sw else None],
+                         o=PeqRoutes(OUTPUT_NAME, 10, zero_til(8), []),
+                         extra=[PeqRoutes(INPUT_NAME, 10, non_sw, []) if non_sw else None],
                          slot_names=slot_names)
 
 
@@ -409,7 +410,7 @@ def make_peq_layout(cfg: dict) -> MinidspDescriptor:
         elif device_type == 'SHD':
             return MinidspDDRC24(slot_names=slot_names)
         elif device_type == 'HTx':
-            return MinidspHTX(sw_channels=cfg.get('sw_channels', None), slot_names=slot_names)
+            return MinidspHTX(input_channels=cfg.get('input_channels', None), slot_names=slot_names)
     elif 'descriptor' in cfg:
         desc: dict = cfg['descriptor']
         named_args = ['name', 'fs', 'routes']


### PR DESCRIPTION
## Summary

This change fixes BEQ application for the MiniDSP Flex HTx.

This change updates the HTx descriptor to use input PEQ, aligning EZBEQ behavior with the latest device architecture and recent `minidsp-rs` fixes.

## Changes

- switch HTx BEQ routing from output PEQ to input PEQ
- apply BEQ only to configured input channels
- ensure non-target channels do not receive BEQ slots
- preserve existing behavior for all other device types

## Validation

Tested on a live MiniDSP Flex HTx.

Validation performed using:
- EZBEQ filter load
- manual filter entry via device console
- REW sweeps before/after

Result:
- EZBEQ-applied filters now match expected response
- behavior is consistent with manual configuration

## Notes

- This aligns EZBEQ with updated HTx support in `minidsp-rs`
- HTx configuration now uses `input_channels` instead of `sw_channels`
- requires HTx version 115 