### PR TITLE
feat: first-class Docker integration

### DIFF
--- a/.github/workflows/create-app.yaml
+++ b/.github/workflows/create-app.yaml
@@ -1,28 +1,42 @@
 name: create apps
 on:
   push:
+    # Only semver-shaped tags trigger the release pipeline. Non-semver tags
+    # (e.g. `edge`, `nightly`) would have produced an empty semver tag set
+    # while the `:latest` raw rule still fired, silently promoting an
+    # unversioned snapshot as latest. Restricting the trigger here makes
+    # that class of mistake impossible.
     tags:
-      - '*'
+      - 'v[0-9]*'
+    branches:
+      - main
+      - dev
+    paths-ignore:
+      - README.md
+      - docs/**
+      - 'docker/README.md'
+  workflow_dispatch:
 defaults:
   run:
     shell: bash
 jobs:
   create_release:
     name: Create Release
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.13
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1
         with:
           virtualenvs-in-project: true
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -36,19 +50,19 @@ jobs:
           source .venv/bin/activate
           pytest --cov=./ezbeq --cov-report=xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4
         with:
           files: ./coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v4.3.1
+        uses: metcalfc/changelog-generator@17705fc5b16e5af8689f309574adecf86bd2eebd  # v4.3.1
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -57,6 +71,7 @@ jobs:
           prerelease: true
   buildpypi:
     name: Publish to Pypi
+    if: startsWith(github.ref, 'refs/tags/')
     needs: create_release
     runs-on: ubuntu-latest
     environment:
@@ -65,9 +80,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Use node.js lts
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: lts/*
       - name: Setup node_modules
@@ -83,16 +98,16 @@ jobs:
         run: |
           echo ${{ steps.get_version.outputs.version-without-v }} > ezbeq/VERSION
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.13
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1
         with:
           virtualenvs-in-project: true
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -104,17 +119,10 @@ jobs:
       - name: Build dist
         run: poetry build
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-      - uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/{owner}/{repo}/dispatches
-          owner: 3ll3d00d
-          repo: ezbeq-docker
-          event_type: 'trigger'
-        env:
-          GITHUB_TOKEN: ${{ secrets.EZBEQJR }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
   buildpyinstaller:
     name: Publish to Github
+    if: startsWith(github.ref, 'refs/tags/')
     needs: create_release
     permissions:
       contents: write
@@ -124,9 +132,9 @@ jobs:
         os: [ macos-latest, windows-latest ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Use node.js lts
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: lts/*
       - name: Setup node_modules
@@ -142,16 +150,16 @@ jobs:
         run: |
           echo ${{ steps.get_version.outputs.version-without-v }} > ezbeq/VERSION
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.13
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1
         with:
           virtualenvs-in-project: true
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -185,3 +193,72 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
             gh release upload ${{ github.ref_name }} ${{ steps.create_dist.outputs.binary_path }}
+  builddocker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      # Set up Python so the Set version step's `python3 -c "import tomllib"`
+      # is guaranteed to find tomllib (stdlib only on 3.11+, and the runner's
+      # system Python may be older).
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: 3.13
+      # Write ezbeq/VERSION so the image banner reports a meaningful version.
+      # Tag pushes get the released version (e.g. "2.7.0"). Branch and dispatch
+      # pushes get a PEP 440 local-version snapshot (e.g. "2.7.0+dev.5341b1d")
+      # so nobody mistakes an unreleased build for the real thing.
+      - name: Set version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "${GITHUB_REF_NAME#v}" > ezbeq/VERSION
+          else
+            BASE=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+            BRANCH_CLEAN=$(echo "$GITHUB_REF_NAME" | tr -c '[:alnum:]' '.' | tr -s '.' | sed 's/^\.//; s/\.$//')
+            echo "${BASE}+${BRANCH_CLEAN}.${GITHUB_SHA:0:7}" > ezbeq/VERSION
+          fi
+          echo "VERSION stamped: $(cat ezbeq/VERSION)"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: production
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_BRANCH=${{ github.ref_name }}
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ ui/              # React source code
 tests/           # Pytest test suite
 docs/            # MkDocs documentation
 examples/        # Device configuration YAML examples
+docker/          # Dockerfile, compose files, helper scripts for containerised deployment
 ```
 
 **Server architecture:** Flask (REST API at `/api`) + Twisted (static frontend + WebSocket) hybrid.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ for local remote control of a minidsp or HTP-1.
 
 # Setup
 
+## Docker (recommended)
+
+A Docker image is published to the GitHub Container Registry on every release:
+
+```bash
+docker pull ghcr.io/3ll3d00d/ezbeq:latest
+```
+
+**Quick start with Docker Compose:**
+
+```bash
+cd docker
+docker compose up -d
+```
+
+Then open `http://localhost:8080` in your browser.
+
+The container exposes port `8080` and expects a volume mounted at `/config` for your `ezbeq.yml`. Copy `docker/.env.example` to `docker/.env` to customise the port or config path.
+
+See [docker/README.md](docker/README.md) for full details including local development builds, manual build instructions, and build targets.
+
 ## Windows / MacOS
 
 Python is required so use an appropriate package manager to install it.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,15 @@
+# OPTIONAL: only needed if your config or port differs from the defaults.
+#
+# Without a .env file:
+#   - docker-compose uses EZBEQ_CONFIG_HOME=~/.ezbeq and EZBEQ_PORT=8080
+#   - bin/run-local auto-detects the port from ezbeq.yml
+#
+# Copy this file to .env (which is git-ignored) and uncomment the lines you need.
+
+# Host path to the directory containing your ezbeq.yml.
+# Defaults to ~/.ezbeq.
+# EZBEQ_CONFIG_HOME=/path/to/your/config
+
+# Port: must match the 'port:' value in ezbeq.yml.
+# Defaults to 8080. bin/run-local auto-detects from ezbeq.yml if not set.
+# EZBEQ_PORT=8080

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,3 @@
+# docker-local test config and env vars (not covered by repo-root .gitignore)
+config/
+.env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,193 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build with four build targets:
+#
+#   base        – shared OS packages + minidsp binary (not used directly)
+#   ui-builder  – compiles the React UI via Yarn/Vite. Feeds both production
+#                 and dev builder stages.
+#   builder     – production Python venv: builds a wheel from local source
+#                 and installs it into /opt/venv. No PyPI fetch; the image
+#                 reflects exactly the source at build time.
+#   production  – default; clean runtime image with non-root user. Built by
+#                 CI / `scripts/publish-image` / `docker buildx bake`.
+#   dev         – local development; Poetry-managed venv, source mounted in
+#                 via docker-compose.dev.yaml so edits take effect on restart.
+
+# ── Base: runtime OS + minidsp binary ────────────────────────────────────────
+# Shared by both the production and dev build targets.
+# python:3.13-slim-trixie: Debian 13 (stable), native Python 3.13, glibc 2.40
+FROM python:3.13-slim-trixie AS base
+
+ENV EZBEQ_CONFIG_HOME=/config
+
+# Install runtime-only dependencies required by the application.
+# BuildKit cache mounts persist /var/cache/apt and /var/lib/apt across builds
+# so repeat builds don't re-download .deb files. The default
+# /etc/apt/apt.conf.d/docker-clean auto-wipes these after every install, so we
+# remove it first to keep the cache effective.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install --no-install-recommends -y \
+    curl \
+    sqlite3 \
+    # minidsp is dynamically linked against libusb-1.0.so.0 and expects it to be
+    # available in the environment, even if USB communication isn't being used
+    libusb-1.0-0
+
+# Always pull the latest minidsp-rs release. Matches upstream author intent
+# and picks up new device support automatically on every image rebuild,
+# without a manual version bump. Dependabot's docker ecosystem can't track
+# `curl`-based downloads from GitHub releases, so a pin would mean recurring
+# manual SHA-256 work; the supply-chain risk from mrene/minidsp-rs (stable
+# repo, no compromise history) doesn't justify that ongoing cost. Revisit
+# if that trust assumption changes.
+RUN ARCH=$(dpkg --print-architecture) && \
+    case "$ARCH" in \
+      amd64) ARCH="x86_64-unknown-linux-gnu" ;; \
+      arm64) ARCH="aarch64-unknown-linux-gnu" ;; \
+      armhf) ARCH="arm-linux-gnueabihf-rpi" ;; \
+      *) echo "Unsupported architecture: $ARCH"; exit 1 ;; \
+    esac && \
+    URL="https://github.com/mrene/minidsp-rs/releases/latest/download/minidsp.${ARCH}.tar.gz" && \
+    curl -fL --retry 3 --retry-delay 5 --max-time 120 -o "minidsp.${ARCH}.tar.gz" "$URL" && \
+    tar -xzf "minidsp.${ARCH}.tar.gz" && \
+    mv minidsp /usr/local/bin/minidsp && \
+    chmod +x /usr/local/bin/minidsp && \
+    rm "minidsp.${ARCH}.tar.gz"
+
+WORKDIR /app
+
+VOLUME ["/config"]
+
+# Git build info - passed via --build-arg in CI, surfaced in the UI footer.
+# Defaults to empty so local builds without args still work.
+ARG GIT_BRANCH=""
+ARG GIT_SHA=""
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV GIT_SHA=${GIT_SHA}
+
+# OCI image annotations. image.source lets GHCR auto-link the package to its
+# GitHub repo on push (unblocking CI write access and surfacing repo info on
+# the package page). image.description populates the package summary.
+# Both default to empty for local builds; publish-image and CI's
+# docker/metadata-action fill them in.
+ARG REPO_URL=""
+ARG REPO_DESCRIPTION="ezbeq: BEQ management for MiniDSP, JRiver, CamillaDSP and other DSPs"
+LABEL org.opencontainers.image.source=$REPO_URL \
+      org.opencontainers.image.description=$REPO_DESCRIPTION
+
+# Document the default port. The actual port is set via 'port:' in ezbeq.yml
+# and must be reflected in the compose file's ports: and healthcheck: entries.
+EXPOSE 8080
+
+# ── UI builder: compile React app ────────────────────────────────────────────
+# Isolated Node stage so node_modules never enters the final image layers.
+# Only the Vite dist output (~a few MB) is copied across; the 200MB+
+# node_modules is discarded after this stage completes.
+# Declared before `builder` because both the production and dev targets copy
+# the compiled UI from here.
+FROM node:22-slim AS ui-builder
+
+WORKDIR /app/ui
+
+# Copy ui source. .yarnrc.yml references .yarn/releases/yarn-4.12.0.cjs so
+# the whole ui/ tree is needed.  node_modules and .yarn/cache are excluded
+# via .dockerignore so the build context stays small.
+COPY ui/ .
+
+# Mount the yarn cache at the location Yarn 4 uses when enableGlobalCache is
+# false (i.e. the project-local .yarn/cache dir).  This persists the package
+# zip archives across builds so yarn install is fast on cache hits.
+RUN --mount=type=cache,target=/app/ui/.yarn/cache \
+    yarn install --silent && yarn build
+
+# ── Production builder: build a wheel from local source + install it ─────────
+# Produces /opt/venv containing ezbeq + runtime deps + the compiled UI. No
+# PyPI fetch; the image reflects exactly the source at build time. On tag
+# builds, CI writes ezbeq/VERSION before `docker build`; that file is included
+# in the wheel via pyproject.toml's `include` list, so the image carries the
+# released version. On branch builds with no VERSION file, config.version
+# falls back to pyproject.toml's declared version.
+FROM base AS builder
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    python3-venv && \
+    python -m pip install --upgrade pip
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# Source layout needed for `pip install .` to build a wheel:
+# - pyproject.toml + poetry.lock: build-system config and deps.
+# - README.md: referenced by pyproject.toml's `readme` field.
+# - ezbeq/: the Python package source (including VERSION when CI wrote it).
+# - ezbeq/ui/: compiled UI from the ui-builder stage, included as package data.
+COPY pyproject.toml poetry.lock README.md ./
+COPY ezbeq/ ./ezbeq/
+COPY --from=ui-builder /app/ezbeq/ui ./ezbeq/ui/
+
+RUN pip install --no-cache-dir .
+
+# ── Production: clean runtime image ──────────────────────────────────────────
+FROM base AS production
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+RUN groupadd -r ezbeq && useradd -r -g ezbeq ezbeq && \
+    chown -R ezbeq:ezbeq /app
+USER ezbeq
+
+# Health check. Reads EZBEQ_PORT from the container env so users with a
+# non-default `port:` in ezbeq.yml get a working healthcheck without a
+# Dockerfile rebuild. Set EZBEQ_PORT in compose's `environment:` block.
+HEALTHCHECK --interval=10s --timeout=2s --start-period=20s \
+    CMD curl -f -s --show-error "http://localhost:${EZBEQ_PORT:-8080}/api/1/version" || exit 1
+
+CMD ["ezbeq"]
+
+# ── Dev: local source build with Poetry ──────────────────────────────────────
+# Build context is the repo root (set by docker-compose.dev.yaml).
+# Node/Yarn are NOT needed here; the compiled UI is copied from ui-builder.
+FROM base AS dev
+
+# Install build tools needed for Poetry / native Python extensions
+# (apt cache mounted so .deb downloads persist across rebuilds).
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    python3-venv
+
+# Install Poetry; cache pip downloads across builds
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install poetry
+
+# Keep the virtualenv inside the project directory (/app/.venv) so it ends up
+# in the image layer.  Without this, Poetry stores the venv under its cache dir
+# (~/.cache/pypoetry/virtualenvs/) which is a cache mount, not persisted in
+# the image, so the container starts with no installed packages.
+RUN poetry config virtualenvs.in-project true
+
+# Install Python deps (without the app itself yet, for better layer caching:
+# this step only reruns when pyproject.toml or poetry.lock changes).
+COPY pyproject.toml poetry.lock ./
+RUN --mount=type=cache,target=/root/.cache/pypoetry/cache \
+    poetry install --no-root
+
+# Copy the compiled UI from the ui-builder stage (a few MB, not node_modules).
+# vite.config.js sets outDir: '../ezbeq/ui' relative to ui/, so output lands
+# at /app/ezbeq/ui inside the ui-builder container.
+COPY --from=ui-builder /app/ezbeq/ui ./ezbeq/ui/
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/pypoetry/cache \
+    poetry install
+
+CMD ["poetry", "run", "ezbeq"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,321 @@
+# ezbeq Docker
+
+Creates and publishes Docker images for [ezbeq](https://github.com/3ll3d00d/ezbeq) to GitHub Packages (GHCR), for use with [MiniDSP](https://www.minidsp.com), [JRiver Media Center](https://www.jriver.com), or any ezBEQ-compatible DSP.
+
+> [!NOTE]
+> This image has not been tested with USB connected devices.
+> There are instructions on how to mount USB devices from another legacy docker image project:
+> - [General docker discussion](https://github.com/jmery/ezbeq-docker/tree/ef3f954f37b1b420e31635a699bfbb864e861ad9?tab=readme-ov-file#general-linux-docker-instructions)
+> - [Synology NAS discussion](https://github.com/jmery/ezbeq-docker/tree/ef3f954f37b1b420e31635a699bfbb864e861ad9?tab=readme-ov-file#general-linux-docker-instructions)
+> - [Higher privileges discussion](https://github.com/jmery/ezbeq-docker/tree/ef3f954f37b1b420e31635a699bfbb864e861ad9?tab=readme-ov-file#note-on-execute-container-using-high-privilege)
+
+## Contents
+
+- [Setup](#setup)
+- [FAQ](#faq)
+- [Running with Docker Compose](#running-with-docker-compose)
+- [Running a local branch](#running-a-local-branch)
+- [Running in Kubernetes](#running-in-kubernetes)
+- [CI / Published Images](#ci--published-images)
+- [Developer Documentation](#developer-documentation)
+
+## Setup
+
+- Expects a volume mapped to `/config` to allow user-supplied `ezbeq.yml`
+- Supports `linux/amd64` and `linux/arm64`
+- Installs the [minidsp-rs](https://github.com/mrene/minidsp-rs) binary automatically
+- Exposes port 8080 by default (configurable via `port:` in `ezbeq.yml`)
+
+Example docker compose file for your reference: [docker-compose.yaml](./docker-compose.yaml)
+
+## FAQ
+
+> Does this docker image work for [MiniDSP](https://www.minidsp.com) devices?
+
+Yes.
+
+> Does this build and publish an image for every ezBEQ release?
+
+Yes - the `create-app.yaml` workflow builds and pushes to GHCR on every push to `main` and on tag creation (alongside the PyPI and pyinstaller release artifacts).
+
+> What architectures are supported?
+
+The docker image gets built to target:
+
+- `linux/amd64`
+- `linux/arm64`
+
+## Running with Docker Compose
+
+`docker compose up -d` works with no configuration - it pulls the published image and mounts `~/.ezbeq` as the config directory by default.
+
+To use a different config directory, set `EZBEQ_CONFIG_HOME` in a `.env` file (copy `.env.example`):
+
+```bash
+cd docker
+cp .env.example .env
+# set EZBEQ_CONFIG_HOME=/path/to/your/config
+docker compose up -d
+```
+
+[docker-compose.yaml](./docker-compose.yaml) also reads `EZBEQ_PORT` from `.env` if your `ezbeq.yml` uses a non-default port. To customise further (e.g. add `extra_hosts` for a MiniDSP hostname, change the user, mount USB devices), add a `docker-compose.override.yaml` alongside it - Docker Compose picks it up automatically.
+
+See the [ezbeq documentation](https://github.com/3ll3d00d/ezbeq) for `ezbeq.yml` configuration options.
+
+---
+
+## Running a local branch
+
+To build and run from a local ezbeq source tree (e.g. an unreleased branch):
+
+**1. Copy `.env.example` to `.env`:**
+
+```bash
+cd docker
+cp .env.example .env
+# edit .env - set EZBEQ_CONFIG_HOME to your config dir if not using ~/.ezbeq
+```
+
+**2. Run it:**
+
+```bash
+scripts/run-local            # build image, start, follow logs (Ctrl+C detaches)
+scripts/run-local --detach   # build image, start, exit (no log tail)
+scripts/run-local --rebuild  # force a full image rebuild
+scripts/run-local --stop     # stop and remove the container
+```
+
+`scripts/run-local` loads `.env`, auto-detects the port from your `ezbeq.yml`, extracts git branch/SHA for the UI footer, and runs:
+```
+docker compose -f docker-compose.yaml -f docker-compose.dev.yaml up --build
+```
+[docker-compose.dev.yaml](./docker-compose.dev.yaml) extends the base config with the `dev` build target, which compiles the React UI from source and installs Python deps via Poetry.
+
+## Build targets
+
+| Target | Purpose |
+|--------|---------|
+| `production` | CI/published image - builds the wheel from local source via `pip install .` |
+| `dev` | Local dev - builds from source using Poetry + Node/Yarn, includes git build info |
+
+---
+
+## Running in Kubernetes
+
+It's assumed that anyone using k8s has an idea of what they're doing and has a particular (network) architecture in their design which will be specific to their own setup.
+
+An example of such a setup is provided by [@Frick](https://github.com/Frick) which may serve as a useful jumping-off point:
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ezbeq
+  labels:
+    kubernetes.io/metadata.name: ezbeq
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ezbeq-config
+  namespace: ezbeq
+data:
+# see https://github.com/3ll3d00d/ezbeq/tree/main/examples for more
+  ezbeq.yml: |
+    accessLogging: false
+    debugLogging: false
+    devices:
+      dsp1:
+        channels:
+          - sub1
+          - sub2
+        ip: 192.168.1.123:80
+        type: htp1
+        autoclear: true
+    port: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: ezbeq
+  name: ezbeq
+  namespace: ezbeq
+spec:
+  progressDeadlineSeconds: 30
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ezbeq
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ezbeq
+    spec:
+      containers:
+        - name: ezbeq
+          image: ghcr.io/3ll3d00d/ezbeq:latest
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /config
+              name: ezbeq-scratch
+            - mountPath: /config/ezbeq.yml
+              name: ezbeq-config
+              subPath: ezbeq.yml
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/1/version
+              port: http
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/1/version
+              port: http
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 256Mi
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /api/1/version
+              port: http
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+      volumes:
+        - name: ezbeq-scratch
+          emptyDir:
+            sizeLimit: 120Mi
+        - name: ezbeq-config
+          configMap:
+            name: ezbeq-config
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ezbeq
+  namespace: ezbeq
+spec:
+  selector:
+    app.kubernetes.io/name: ezbeq
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ezbeq
+  namespace: ezbeq
+  annotations:
+    cert-manager.io/cluster-issuer: lets-encrypt
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/websocket-services: "ezbeq"
+    external-dns.alpha.kubernetes.io/hostname: ezbeq.yourdomain.dev
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: ezbeq.yourdomain.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ezbeq
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - ezbeq.yourdomain.dev
+      secretName: ezbeq-tls
+```
+
+---
+
+## CI / Published Images
+
+The `create-app.yaml` workflow publishes images to GHCR (same workflow that cuts PyPI and pyinstaller releases):
+
+| Trigger | Image tag(s) | What it builds |
+|---------|--------------|----------------|
+| Push to `main` | `:latest` | Production target - wheel built from local source |
+| Push to `dev` | `:dev` | Production target - wheel built from local source (snapshot version) |
+| Tag push (e.g. `v1.2.3`) | `:1.2.3`, `:1.2`, `:1`, `:latest` | Production target - released version baked in |
+| Manual (`workflow_dispatch`) | derived from ref | Production target from any branch |
+
+To use a published image:
+
+```yaml
+# docker-compose.yaml
+image: ghcr.io/<owner>/ezbeq:latest
+```
+
+### Publishing manually
+
+`scripts/publish-image` builds from the current source tree and pushes to GHCR. Useful for demo images, one-off builds, or branches without CI:
+
+```bash
+scripts/publish-image              # prompt for tag (default: demo)
+scripts/publish-image demo         # build + push ghcr.io/<owner>/ezbeq:demo
+scripts/publish-image demo v1.2.3  # multiple tags in one push
+OWNER=3ll3d00d scripts/publish-image demo           # override the GHCR owner
+PLATFORMS=linux/amd64 scripts/publish-image demo    # single-arch (faster)
+```
+
+Produces a multi-arch manifest (`linux/amd64` + `linux/arm64`) in a single buildx step, so the image runs natively on both Apple Silicon and x86_64 hosts. Requires `docker login ghcr.io` first (use a PAT with `write:packages`) and a buildx builder supporting the requested platforms. On Docker Desktop this works out of the box; elsewhere see [Docker buildx docs](https://docs.docker.com/build/building/multi-platform/). The owner is auto-detected from the `origin` remote unless `OWNER` is set. GIT_BRANCH and GIT_SHA are extracted from the local repo and baked into the image so the UI footer reflects the exact source.
+
+---
+
+## Developer Documentation
+
+### Manual build
+
+```bash
+# From repo root:
+docker build -f docker/Dockerfile --target production -t ezbeq .
+docker build -f docker/Dockerfile --target dev -t ezbeq-dev .
+```
+
+### Multi-platform Docker image
+
+Build for two architectures in parallel and push:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f docker/Dockerfile \
+  -t <HUB USERNAME>/ezbeq:latest \
+  --push .
+```
+
+#### Buildx setup
+
+Requires Docker's `buildx`:
+
+- `docker buildx create --use`
+- `docker buildx inspect --bootstrap`

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -1,0 +1,24 @@
+# Local development compose override.
+# Used by scripts/run-local via: docker compose -f docker-compose.yaml -f docker-compose.dev.yaml
+# Not loaded automatically; regular users running `docker compose up` are unaffected.
+#
+# Build context is the repo root (..) so source changes are picked up.
+# All values are read from environment variables set in .env (copy .env.example).
+
+services:
+  ezbeq-docker:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: dev
+    image: ezbeq-local
+    container_name: ezbeq-local
+    environment:
+      # Echo every HTTP request to stdout so it appears in `docker compose logs`.
+      - EZBEQ_ACCESS_LOG_STDOUT=1
+      # Git build info injected by scripts/run-local - surfaces in the UI footer.
+      - GIT_BRANCH
+      - GIT_SHA
+    # Optional: map hostnames to IPs for your network setup
+    # extra_hosts:
+    #   - "minidsp:192.168.1.86"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,28 @@
+# Reference docker-compose for the published ezbeq image. Use directly, or
+# layer a docker-compose.override.yaml on top (compose picks it up
+# automatically) for site-specific extras like extra_hosts or USB mounts.
+#
+# All ${VAR:-default} entries read from docker/.env if present (see
+# .env.example) or from the shell environment.
+
+services:
+  ezbeq-docker:
+    # EZBEQ_OWNER lets a fork pull from its own GHCR namespace. Defaults to
+    # the upstream 3ll3d00d. EZBEQ_TAG selects the GHCR tag: :latest (most
+    # recent main build), :dev (dev branch), or a specific release like
+    # :v1.2.3. scripts/run-published exports both from its arguments.
+    image: ghcr.io/${EZBEQ_OWNER:-3ll3d00d}/ezbeq:${EZBEQ_TAG:-latest}
+    container_name: ezbeq
+    restart: unless-stopped
+    # EZBEQ_PORT MUST match `port:` in ezbeq.yml. Passed through to the
+    # container so the image's HEALTHCHECK (defined in the Dockerfile,
+    # uses runtime $EZBEQ_PORT expansion) reads it without a rebuild.
+    # The Dockerfile HEALTHCHECK already includes start-period and the
+    # right interval/retries; not overriding here.
+    environment:
+      - EZBEQ_PORT=${EZBEQ_PORT:-8080}
+    # EZBEQ_CONFIG_HOME is the host directory holding your ezbeq.yml.
+    volumes:
+      - ${EZBEQ_CONFIG_HOME:-~/.ezbeq}:/config
+    ports:
+      - "${EZBEQ_PORT:-8080}:${EZBEQ_PORT:-8080}"

--- a/docker/scripts/_lib.sh
+++ b/docker/scripts/_lib.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Shared helpers for scripts under docker/scripts. Source from another script:
+#     source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+#
+# Exports DOCKER_DIR, REPO_ROOT.
+# Provides ezbeq::* functions for help, env loading, config + git + owner.
+
+# Derive paths from this file's location, independent of caller's CWD.
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="$(cd "$_LIB_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$DOCKER_DIR/.." && pwd)"
+
+# Caller script path captured at source time so print_help survives later cd's.
+_CALLER_PATH="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)/$(basename "${BASH_SOURCE[1]}")"
+
+# Print the caller's top comment block as usage. Stops at the first line that
+# isn't a `#` comment, so help output stays in sync as the header changes.
+ezbeq::print_help() {
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$_CALLER_PATH"
+}
+
+# Source docker/.env into the environment if present.
+ezbeq::load_env() {
+    local env_file="$DOCKER_DIR/.env"
+    [[ -f "$env_file" ]] || return 0
+    set -o allexport
+    # shellcheck disable=SC1090
+    source "$env_file"
+    set +o allexport
+}
+
+# Resolve config path, auto-detect EZBEQ_PORT from its `port:` key if unset,
+# export EZBEQ_CONFIG_HOME + EZBEQ_PORT for docker-compose interpolation.
+#
+# Resolution order: explicit EZBEQ_CONFIG > EZBEQ_CONFIG_HOME/ezbeq.yml > $HOME/.ezbeq/ezbeq.yml
+# A user-set EZBEQ_CONFIG_HOME (the public knob documented in .env.example) is
+# preserved and used for the compose volume mount; we only auto-derive it from
+# EZBEQ_CONFIG when neither is explicitly set.
+ezbeq::resolve_config() {
+    if [[ -z "${EZBEQ_CONFIG:-}" ]]; then
+        if [[ -n "${EZBEQ_CONFIG_HOME:-}" ]]; then
+            EZBEQ_CONFIG="$EZBEQ_CONFIG_HOME/ezbeq.yml"
+        else
+            EZBEQ_CONFIG="$HOME/.ezbeq/ezbeq.yml"
+        fi
+    fi
+    [[ -f "$EZBEQ_CONFIG" ]] || {
+        echo "Error: ezbeq.yml not found at $EZBEQ_CONFIG" >&2
+        echo "       Create it, or set EZBEQ_CONFIG_HOME in docker/.env." >&2
+        exit 1
+    }
+    if [[ -z "${EZBEQ_PORT:-}" ]]; then
+        EZBEQ_PORT=$(awk -F: '/^[[:space:]]*port[[:space:]]*:/ {gsub(/[ \t\r#].*/,"",$2); gsub(/[ \t\r]/,"",$2); print $2; exit}' "$EZBEQ_CONFIG")
+        EZBEQ_PORT="${EZBEQ_PORT:-8080}"
+    fi
+    export EZBEQ_CONFIG_HOME="${EZBEQ_CONFIG_HOME:-$(dirname "$EZBEQ_CONFIG")}"
+    export EZBEQ_PORT
+}
+
+# Validate an OCI image tag: non-empty and no slashes.
+ezbeq::validate_tag() {
+    local tag="$1"
+    [[ -n "$tag" ]] || { echo "Error: image tag is empty." >&2; exit 2; }
+    [[ "$tag" != */* ]] || {
+        echo "Error: image tag '$tag' contains '/' which is not valid in an OCI tag." >&2
+        echo "       Try '${tag//\//-}' instead." >&2
+        exit 2
+    }
+}
+
+# Populate GIT_BRANCH and GIT_SHA. Silent empty strings on failure.
+ezbeq::resolve_git_info() {
+    GIT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    GIT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "")
+}
+
+# Resolve GHCR owner: OWNER env wins, else parse `origin` remote.
+ezbeq::resolve_owner() {
+    [[ -n "${OWNER:-}" ]] && return 0
+    local origin
+    origin=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
+    OWNER=$(echo "$origin" | sed -nE 's#.*[:/]([^/]+)/ezbeq(\.git)?$#\1#p')
+    [[ -n "$OWNER" ]] || {
+        echo "Error: could not determine GHCR owner from origin remote." >&2
+        echo "       origin url: ${origin:-<unset>}" >&2
+        echo "       Set OWNER=<github-user-or-org> and rerun." >&2
+        exit 1
+    }
+}

--- a/docker/scripts/publish-image
+++ b/docker/scripts/publish-image
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Build and push a multi-arch Docker image tagged ghcr.io/<owner>/ezbeq:<tag>.
+# Always rebuilds from source. Prompts for a tag if none supplied.
+#
+# Produces images for both linux/amd64 and linux/arm64 (override with PLATFORMS).
+#
+# Usage:
+#   scripts/publish-image              # prompt for tag (default: dev)
+#   scripts/publish-image dev         # build + push ghcr.io/<owner>/ezbeq:dev
+#   scripts/publish-image dev v1.2.3  # multiple tags in one push
+#   OWNER=3ll3d00d scripts/publish-image dev           # override GHCR owner
+#   PLATFORMS=linux/amd64 scripts/publish-image dev    # single-arch (faster)
+#
+# Requires `docker login ghcr.io` (PAT with write:packages) and a buildx
+# builder that supports the requested platforms. Docker Desktop works out
+# of the box; elsewhere:
+#   docker buildx create --name multi --use && docker buildx inspect --bootstrap
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cd "$REPO_ROOT"
+
+case "${1:-}" in
+    -h|--help) ezbeq::print_help; exit 0 ;;
+esac
+
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
+
+ezbeq::resolve_owner
+ezbeq::resolve_git_info
+
+tags=("$@")
+if [[ ${#tags[@]} -eq 0 ]]; then
+    [[ -t 0 ]] || { echo "Error: no tag given and stdin is not a TTY." >&2; exit 2; }
+    read -r -p "Image tag [dev]: " tag
+    tags=("${tag:-dev}")
+fi
+for t in "${tags[@]}"; do ezbeq::validate_tag "$t"; done
+
+if ! git -C "$REPO_ROOT" diff --quiet 2>/dev/null || ! git -C "$REPO_ROOT" diff --cached --quiet 2>/dev/null; then
+    echo "Warning: uncommitted changes present; baked-in GIT_SHA ($GIT_SHA) won't reflect them." >&2
+fi
+
+tag_args=()
+for t in "${tags[@]}"; do
+    tag_args+=(-t "ghcr.io/${OWNER}/ezbeq:${t}")
+done
+
+REPO_URL="https://github.com/${OWNER}/ezbeq"
+
+# Stamp ezbeq/VERSION with a PEP 440 local-version snapshot
+# (<pyproject.version>+<branch>.<short-sha>) so the image banner makes clear
+# this is an unreleased build. ezbeq/VERSION is gitignored. Tag releases go
+# through CI, not this script.
+BASE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('$REPO_ROOT/pyproject.toml','rb'))['project']['version'])" 2>/dev/null || echo "0.0.0")
+BRANCH_CLEAN=$(echo "${GIT_BRANCH:-unknown}" | tr -c '[:alnum:]' '.' | tr -s '.' | sed 's/^\.//; s/\.$//')
+VERSION_STAMP="${BASE_VERSION}+${BRANCH_CLEAN}.${GIT_SHA:-unknown}"
+echo "$VERSION_STAMP" > "$REPO_ROOT/ezbeq/VERSION"
+
+echo "Owner     : $OWNER"
+echo "Branch    : ${GIT_BRANCH:-unknown}"
+echo "SHA       : ${GIT_SHA:-unknown}"
+echo "Version   : $VERSION_STAMP"
+echo "Platforms : $PLATFORMS"
+echo "Tags      : ${tags[*]}"
+echo "Repo URL  : $REPO_URL"
+echo
+
+docker buildx build \
+    --platform "$PLATFORMS" \
+    --target production \
+    --build-arg "GIT_BRANCH=${GIT_BRANCH}" \
+    --build-arg "GIT_SHA=${GIT_SHA}" \
+    --build-arg "REPO_URL=${REPO_URL}" \
+    -f "$REPO_ROOT/docker/Dockerfile" \
+    "${tag_args[@]}" \
+    --push \
+    "$REPO_ROOT" || {
+        echo "Error: buildx build/push failed. Did you run 'docker login ghcr.io' (PAT with write:packages)?" >&2
+        echo "       For multi-arch builds, ensure your buildx builder supports $PLATFORMS." >&2
+        exit 1
+    }
+
+echo
+echo "Published ${#tags[@]} tag(s) to ghcr.io/${OWNER}/ezbeq for platforms: $PLATFORMS"

--- a/docker/scripts/run-local
+++ b/docker/scripts/run-local
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Build and run ezbeq from the local source tree (dev Dockerfile target).
+# Loads optional configuration from docker/.env (copy .env.example to override).
+# A re-invocation while the container is running restarts it (--force-recreate)
+# so code/image changes always take effect.
+#
+# Usage:
+#   scripts/run-local               # build + (re)start + follow logs
+#   scripts/run-local --detach, -d  # build + (re)start detached; print URL
+#   scripts/run-local --rebuild     # force clean rebuild + follow logs
+#   scripts/run-local --stop        # stop and remove the container
+#   scripts/run-local --help        # show this message
+#
+# Ctrl+C while tailing logs detaches from the stream; the container keeps
+# running. Use --stop to tear it down.
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cd "$DOCKER_DIR"
+
+COMPOSE=(docker compose -f docker-compose.yaml -f docker-compose.dev.yaml)
+
+case "${1:-}" in
+    -h|--help) ezbeq::print_help; exit 0 ;;
+    --stop) "${COMPOSE[@]}" down; exit 0 ;;
+esac
+
+ezbeq::load_env
+ezbeq::resolve_config
+ezbeq::resolve_git_info
+export GIT_BRANCH GIT_SHA
+
+UP_FLAGS=(--build --force-recreate)
+FOLLOW_LOGS=1
+case "${1:-}" in
+    "") ;;
+    -d|--detach) FOLLOW_LOGS=0 ;;
+    --rebuild) UP_FLAGS=(--build --no-cache --force-recreate) ;;
+    *) echo "Error: unknown option '$1'. Run with --help." >&2; exit 2 ;;
+esac
+
+echo "Source : $REPO_ROOT"
+echo "Config : $EZBEQ_CONFIG"
+echo "Port   : $EZBEQ_PORT"
+echo "Branch : ${GIT_BRANCH:-unknown}"
+echo "SHA    : ${GIT_SHA:-unknown}"
+
+"${COMPOSE[@]}" up -d "${UP_FLAGS[@]}"
+
+echo
+echo "Running at http://localhost:$EZBEQ_PORT"
+if (( FOLLOW_LOGS )); then
+    echo "(Ctrl+C detaches from logs; the container keeps running)"
+    echo
+    "${COMPOSE[@]}" logs -f
+else
+    echo "Logs: scripts/run-local   |   Stop: scripts/run-local --stop"
+fi

--- a/docker/scripts/run-published
+++ b/docker/scripts/run-published
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Pull and run a PUBLISHED ezbeq image from GHCR. Use to verify that an image
+# pushed by CI or scripts/publish-image actually works: prod's behavior
+# without needing prod hardware.
+#
+# No build happens; the image is pulled fresh on every invocation
+# (docker compose up --pull always --force-recreate).
+#
+# Container name is `ezbeq` (the base compose default), so it won't collide
+# with `ezbeq-local` from scripts/run-local. It WILL collide on port 8080 if
+# run-local is up; stop it first with `scripts/run-local --stop`.
+#
+# Usage:
+#   scripts/run-published               # prompt for tag (default: dev)
+#   scripts/run-published dev          # pull + run ghcr.io/<owner>/ezbeq:dev
+#   scripts/run-published v1.2.3        # pull + run a specific version tag
+#   scripts/run-published dev --detach # same, detached (no log tail)
+#   scripts/run-published --stop        # stop and remove the container
+#   scripts/run-published --help
+set -euo pipefail
+# shellcheck source=_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cd "$DOCKER_DIR"
+
+COMPOSE=(docker compose -f docker-compose.yaml)
+
+case "${1:-}" in
+    -h|--help) ezbeq::print_help; exit 0 ;;
+    --stop) "${COMPOSE[@]}" down; exit 0 ;;
+esac
+
+ezbeq::load_env
+ezbeq::resolve_config
+
+TAG=""
+FOLLOW_LOGS=1
+for arg in "$@"; do
+    case "$arg" in
+        -d|--detach) FOLLOW_LOGS=0 ;;
+        -*) echo "Error: unknown option '$arg'. Run with --help." >&2; exit 2 ;;
+        *)
+            [[ -z "$TAG" ]] || { echo "Error: only one tag may be given (got '$TAG' and '$arg')." >&2; exit 2; }
+            TAG="$arg"
+            ;;
+    esac
+done
+
+if [[ -z "$TAG" ]]; then
+    [[ -t 0 ]] || { echo "Error: no tag given and stdin is not a TTY. Pass a tag: scripts/run-published dev" >&2; exit 2; }
+    read -r -p "Image tag [dev]: " TAG
+    TAG="${TAG:-dev}"
+fi
+ezbeq::validate_tag "$TAG"
+
+ezbeq::resolve_owner
+export EZBEQ_TAG="$TAG" EZBEQ_OWNER="$OWNER"
+
+echo "Image  : ghcr.io/${OWNER}/ezbeq:${EZBEQ_TAG}"
+echo "Config : $EZBEQ_CONFIG"
+echo "Port   : $EZBEQ_PORT"
+echo
+
+"${COMPOSE[@]}" up -d --pull always --force-recreate
+
+echo
+echo "Running at http://localhost:$EZBEQ_PORT"
+if (( FOLLOW_LOGS )); then
+    echo "(Ctrl+C detaches from logs; the container keeps running)"
+    echo
+    "${COMPOSE[@]}" logs -f
+else
+    echo "Logs: scripts/run-published   |   Stop: scripts/run-published --stop"
+fi

--- a/docker/scripts/test-docker-git-info
+++ b/docker/scripts/test-docker-git-info
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Integration test: verify that GIT_BRANCH and GIT_SHA are visible in the
+# version API when the Docker image is built with --build-arg.
+#
+# Uses a minimal inline Dockerfile so the test works on any branch that
+# has the version API git_info support (no dependency on docker/).
+#
+# Usage:
+#   scripts/test-docker-git-info
+#
+# Exit code 0 = pass, 1 = fail.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CONTAINER_NAME="ezbeq-git-info-test"
+TEST_BRANCH="test/integration-branch"
+TEST_SHA="abc1234"
+PORT=19968
+IMAGE="ezbeq-git-info-test:latest"
+
+cleanup() {
+    docker rm -f "$CONTAINER_NAME" > /dev/null 2>&1 || true
+    rm -f "$DOCKERFILE_TMP" 2>/dev/null || true
+    rm -rf "$STUB_CONFIG_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ── Inline Dockerfile (minimal, just enough to run ezbeq) ────────────────────
+DOCKERFILE_TMP=$(mktemp)
+cat > "$DOCKERFILE_TMP" << 'DOCKERFILE'
+FROM python:3.13-slim-trixie
+ARG GIT_BRANCH=""
+ARG GIT_SHA=""
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV GIT_SHA=${GIT_SHA}
+ENV EZBEQ_CONFIG_HOME=/config
+WORKDIR /app
+RUN pip install --no-cache-dir poetry
+COPY pyproject.toml poetry.lock ./
+COPY ezbeq/ ./ezbeq/
+COPY README.md ./
+RUN mkdir -p ezbeq/ui && echo '<html><body>test</body></html>' > ezbeq/ui/index.html
+RUN poetry config virtualenvs.create false && poetry install --no-interaction
+VOLUME ["/config"]
+CMD ["ezbeq"]
+DOCKERFILE
+
+echo "=== Building Docker image with GIT_BRANCH=$TEST_BRANCH GIT_SHA=$TEST_SHA ==="
+docker build \
+    -f "$DOCKERFILE_TMP" \
+    --build-arg "GIT_BRANCH=$TEST_BRANCH" \
+    --build-arg "GIT_SHA=$TEST_SHA" \
+    -t "$IMAGE" \
+    . 2>&1 | tail -5
+
+echo "=== Starting container on port $PORT ==="
+STUB_CONFIG_DIR=$(mktemp -d)
+cat > "$STUB_CONFIG_DIR/ezbeq.yml" << 'YAML'
+port: 19968
+accessLogging: false
+debugLogging: false
+devices:
+  master:
+    type: minidsp
+    exe: stub
+YAML
+
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    -p "$PORT:$PORT" \
+    -v "$STUB_CONFIG_DIR:/config" \
+    "$IMAGE" > /dev/null
+
+echo "=== Waiting for server to be ready ==="
+RETRIES=30
+for i in $(seq 1 $RETRIES); do
+    if curl -sf "http://localhost:$PORT/api/1/version" > /dev/null 2>&1; then
+        break
+    fi
+    if [ "$i" -eq "$RETRIES" ]; then
+        echo "FAIL: server did not start within ${RETRIES}s"
+        docker logs "$CONTAINER_NAME" 2>&1 | tail -20
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "=== Checking /api/1/version ==="
+RESPONSE=$(curl -sf "http://localhost:$PORT/api/1/version")
+echo "Response: $RESPONSE"
+
+# Verify branch
+ACTUAL_BRANCH=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('branch',''))")
+if [ "$ACTUAL_BRANCH" != "$TEST_BRANCH" ]; then
+    echo "FAIL: expected branch '$TEST_BRANCH', got '$ACTUAL_BRANCH'"
+    exit 1
+fi
+
+# Verify SHA
+ACTUAL_SHA=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))")
+if [ "$ACTUAL_SHA" != "$TEST_SHA" ]; then
+    echo "FAIL: expected sha '$TEST_SHA', got '$ACTUAL_SHA'"
+    exit 1
+fi
+
+# Verify version is non-empty and not 'UNKNOWN'. The exact value depends on
+# the fallback chain in Config.version: ezbeq/VERSION (if present) →
+# pyproject.toml → importlib.metadata. This image has no VERSION file but
+# has the source tree COPYed in, so pyproject.toml's project.version should
+# resolve. A bare 'UNKNOWN' or '' indicates the fallback chain is broken.
+ACTUAL_VERSION=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))")
+if [ -z "$ACTUAL_VERSION" ] || [ "$ACTUAL_VERSION" = "UNKNOWN" ]; then
+    echo "FAIL: expected a real version, got '$ACTUAL_VERSION'"
+    exit 1
+fi
+
+echo ""
+echo "PASS: version API returned version=$ACTUAL_VERSION branch=$ACTUAL_BRANCH sha=$ACTUAL_SHA"

--- a/ezbeq/config.py
+++ b/ezbeq/config.py
@@ -210,7 +210,7 @@ class Config:
                 f"  (or set exe: stub in your ezbeq.yml)\n"
                 f"\n"
                 f"Or run via Docker (no local deps required):\n"
-                f"  https://github.com/3ll3d00d/ezbeq-docker"
+                f"  https://github.com/3ll3d00d/ezbeq/tree/main/docker"
             )
         return cmd[options.split(' ')] if options else cmd
 
@@ -219,18 +219,54 @@ class Config:
         return CamillaDspClient(ip, port, listener)
 
     @property
-    def version(self):
+    def version(self) -> str:
+        """Resolve the running ezbeq version, trying three sources in order.
+
+        1. **VERSION file** at the package root (or ``sys._MEIPASS`` when
+           running as a PyInstaller bundle). Written by CI on tag builds and
+           on branch builds (where it carries a PEP 440 local-version
+           snapshot like ``2.7.0+dev.5341b1d``). Authoritative when present.
+        2. **pyproject.toml** ``project.version`` (or legacy
+           ``tool.poetry.version``). Used in source-tree builds where no
+           VERSION file has been written. Always reflects the in-progress
+           version, unlike importlib.metadata which can be stale after a
+           pyproject bump.
+        3. **importlib.metadata** for the installed ``ezbeq`` package. The
+           production Docker image's last resort: pip-installed package,
+           no source tree, no VERSION file.
+
+        Returns the literal string ``'UNKNOWN'`` only if all three sources
+        fail. A malformed pyproject.toml logs a warning and falls through
+        to step 3 rather than raising.
+        """
+        # Step 1: VERSION file
         if getattr(sys, 'frozen', False):
-            # pyinstaller lets you copy files to arbitrary locations under the _MEIPASS root dir
-            root = os.path.join(sys._MEIPASS)
+            # PyInstaller copies bundled files to a temp dir at _MEIPASS.
+            root = sys._MEIPASS
         else:
             root = os.path.dirname(__file__)
         v_name = os.path.join(root, 'VERSION')
-        v = 'UNKNOWN'
         if os.path.exists(v_name):
-            with open(v_name) as f:
-                v = f.read()
-        return v
+            with open(v_name, encoding='utf-8-sig') as f:
+                return f.read().strip()
+        # Step 2: pyproject.toml
+        import tomllib
+        pyproject = os.path.join(os.path.dirname(root), 'pyproject.toml')
+        if os.path.exists(pyproject):
+            try:
+                with open(pyproject, 'rb') as f:
+                    data = tomllib.load(f)
+                v = data.get('project', {}).get('version') or data.get('tool', {}).get('poetry', {}).get('version')
+                if v:
+                    return v
+            except (OSError, tomllib.TOMLDecodeError) as e:
+                self.logger.warning('Failed to read pyproject.toml for version: %s', e)
+        # Step 3: installed package metadata
+        from importlib.metadata import version as _pkg_version, PackageNotFoundError
+        try:
+            return _pkg_version('ezbeq')
+        except PackageNotFoundError:
+            return 'UNKNOWN'
 
     @property
     def git_info(self) -> dict:

--- a/tests/test_version_api.py
+++ b/tests/test_version_api.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -106,3 +107,104 @@ def test_version_env_vars_surfaced_in_api(httpserver, tmp_path, monkeypatch):
     assert r.status_code == 200
     assert r.json['branch'] == 'feats/docker-branch'
     assert r.json['sha'] == 'cafebabe'
+
+
+# ─── Config.version fallback chain ──────────────────────────────────────────
+# These tests exercise the actual fallback logic (VERSION file → pyproject.toml
+# → importlib.metadata → 'UNKNOWN'). They sidestep the VersionedConfig stub
+# above, which overrides `version` entirely.
+
+def _make_fake_root(tmp_path, version_content=None, pyproject_content=None):
+    """Stand up a fake ezbeq package directory under tmp_path.
+
+    Mirrors the on-disk layout that Config.version reads:
+      <root>/ezbeq/__init__.py     ← config.py's __file__ is patched here
+      <root>/ezbeq/VERSION         ← optional VERSION file
+      <root>/pyproject.toml        ← optional pyproject.toml
+    """
+    fake_ezbeq = tmp_path / 'ezbeq'
+    fake_ezbeq.mkdir()
+    (fake_ezbeq / '__init__.py').write_text('')
+    if version_content is not None:
+        (fake_ezbeq / 'VERSION').write_text(version_content)
+    if pyproject_content is not None:
+        (tmp_path / 'pyproject.toml').write_text(pyproject_content)
+    return fake_ezbeq
+
+
+def _bare_config(monkeypatch, fake_root):
+    """Build a Config instance whose `version` property reads from fake_root.
+
+    Skips Config.__init__ entirely; we only care about the `version` property.
+    """
+    from ezbeq import config as config_module
+    monkeypatch.setattr(config_module, '__file__', str(fake_root / '__init__.py'))
+    cfg = config_module.Config.__new__(config_module.Config)
+    cfg.logger = logging.getLogger('test.config')
+    return cfg
+
+
+def test_version_from_VERSION_file(tmp_path, monkeypatch):
+    fake = _make_fake_root(tmp_path, version_content='9.8.7\n')
+    cfg = _bare_config(monkeypatch, fake)
+    assert cfg.version == '9.8.7'
+
+
+def test_version_strips_VERSION_file_whitespace(tmp_path, monkeypatch):
+    # Ensure trailing newline / surrounding whitespace doesn't bleed into
+    # consumers like the API response or the banner.
+    fake = _make_fake_root(tmp_path, version_content='  1.2.3  \n')
+    cfg = _bare_config(monkeypatch, fake)
+    assert cfg.version == '1.2.3'
+
+
+def test_version_from_pyproject_project_version(tmp_path, monkeypatch):
+    pyproject = '[project]\nname = "ezbeq"\nversion = "5.4.3"\n'
+    fake = _make_fake_root(tmp_path, pyproject_content=pyproject)
+    cfg = _bare_config(monkeypatch, fake)
+    assert cfg.version == '5.4.3'
+
+
+def test_version_from_pyproject_legacy_poetry_section(tmp_path, monkeypatch):
+    # Older pyproject.toml put the version under [tool.poetry] rather than
+    # [project]. Keep the legacy arm working so a downstream fork that hasn't
+    # migrated still resolves a sane version.
+    pyproject = '[tool.poetry]\nname = "ezbeq"\nversion = "4.3.2"\n'
+    fake = _make_fake_root(tmp_path, pyproject_content=pyproject)
+    cfg = _bare_config(monkeypatch, fake)
+    assert cfg.version == '4.3.2'
+
+
+def test_version_falls_back_to_metadata_when_no_VERSION_or_pyproject(tmp_path, monkeypatch):
+    # Production Docker image case: ezbeq is pip-installed, source tree is
+    # absent. importlib.metadata is the source of truth.
+    fake = _make_fake_root(tmp_path)
+    cfg = _bare_config(monkeypatch, fake)
+    v = cfg.version
+    assert v != 'UNKNOWN'
+    assert v
+    # Should look like a real version string (starts with a digit).
+    assert v[0].isdigit()
+
+
+def test_version_unknown_when_nothing_resolves(tmp_path, monkeypatch):
+    # Defensive: VERSION absent, pyproject absent, package not installed under
+    # this name. Fallback returns the literal 'UNKNOWN' rather than raising.
+    fake = _make_fake_root(tmp_path)
+    cfg = _bare_config(monkeypatch, fake)
+    import importlib.metadata as md
+    def _missing(name):
+        raise md.PackageNotFoundError(name)
+    monkeypatch.setattr(md, 'version', _missing)
+    assert cfg.version == 'UNKNOWN'
+
+
+def test_version_recovers_from_corrupt_pyproject(tmp_path, monkeypatch, caplog):
+    # A malformed pyproject.toml shouldn't be a silent failure: it should log
+    # a warning and continue down the chain.
+    fake = _make_fake_root(tmp_path, pyproject_content='this is [ not valid toml')
+    cfg = _bare_config(monkeypatch, fake)
+    with caplog.at_level(logging.WARNING, logger='test.config'):
+        v = cfg.version
+    assert v != 'UNKNOWN'  # falls through to importlib.metadata
+    assert any('pyproject.toml' in record.message for record in caplog.records)


### PR DESCRIPTION
Closes astubbs/ezbeq#10 by moving the contents of the separate 3ll3d00d/ezbeq-docker repo into this repo under `docker/`. CI now publishes the image to GHCR alongside the PyPI and GH Release artifacts.

## What's in here

**Significant change from the original ezbeq-docker design:** the production image now builds the ezbeq wheel from local source (`pip install .`) instead of installing it from PyPI. Each image reflects the exact source at build time, so demo/feature-branch images work without waiting for a PyPI release.

### Files
- `docker/Dockerfile`: multi-stage (`base` -> `ui-builder` -> `builder` -> `production`/`dev`), multi-arch (linux/amd64, linux/arm64). Healthcheck reads `${EZBEQ_PORT:-8080}` from container env so non-default ports work without a Dockerfile rebuild.
- `docker/scripts/{run-local, run-published, publish-image, test-docker-git-info, _lib.sh}`: developer loop + manual GHCR publish + integration test, sharing helpers via `_lib.sh`.
- `docker/{docker-compose.yaml, docker-compose.dev.yaml, README.md, .env.example, .gitignore}`.
- `builddocker` job in `.github/workflows/create-app.yaml`: multi-arch via QEMU + buildx, GHA cache, OCI labels for GHCR auto-link, PEP 440 snapshot version stamping for non-tag builds. Every third-party action SHA-pinned with a trailing `# vN` comment for Dependabot. Tag trigger restricted from `*` to `v[0-9]*` so non-semver tags can't accidentally promote a snapshot to `:latest`.
- `ezbeq/config.py`: version-resolution fallback chain (VERSION file -> `pyproject.toml` -> `importlib.metadata` -> `'UNKNOWN'`). VERSION file read with `utf-8-sig` encoding to tolerate BOM. 7 unit tests for the chain in `tests/test_version_api.py`.
- `agents.md` -> `AGENTS.md` rename for case-sensitive filesystems.

### Notable design decisions
- **`EZBEQ_OWNER` flows through compose** (`ghcr.io/${EZBEQ_OWNER:-3ll3d00d}/ezbeq:...`) so forks pull from their own GHCR namespace.
- **`EZBEQ_CONFIG_HOME` is the canonical user-facing config-path knob** documented in `.env.example`. `EZBEQ_CONFIG` is preserved as an explicit override.
- **Tag validation** in scripts rejects empty + slash-containing tags (e.g. `feat/pr-91`) with actionable error messages instead of opaque registry errors.
- **minidsp-rs binary** still pulled from `releases/latest` (matches your original intent). Dependabot can't track `curl`-based GitHub release downloads, so pinning would mean recurring manual SHA work for negligible supply-chain gain. The `curl` invocation does add `-fL --retry / --max-time` for build resilience.

## Follow-ups for you to decide

1. **3ll3d00d/ezbeq-docker can be archived once this merges.** All content is here and CI no longer dispatches to that repo. Image path changes from `ghcr.io/3ll3d00d/ezbeq-docker` to `ghcr.io/3ll3d00d/ezbeq`, so release notes should mention the rename for existing users to update their compose files.
2. **Optional `.github/dependabot.yml`** to monitor GitHub Actions + Docker base images so the SHA pins stay fresh automatically. Happy to follow up if you want.

## Verified

- `poetry run pytest`: full suite passes (13 version-API tests including 7 new fallback-chain tests).
- `docker/scripts/test-docker-git-info`: builds image with `GIT_BRANCH`/`GIT_SHA` build args, runs container, asserts `/api/1/version` returns the correct version + branch + sha.
- Local builds tested on linux/amd64 and linux/arm64.