### PR TITLE
feat: real-time volume control, What's New feed, WebSocket reconnect

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Never send these to the Docker build context
+
+# JS build artefacts — Docker installs and builds these itself
+ui/node_modules/
+ui/.yarn/cache/
+ui/dist/
+
+# Python build artefacts
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+*.egg-info/
+dist/
+build/
+
+# The built React output — Docker builds this inside the image
+ezbeq/ui/
+
+# Git history
+.git/
+.gitignore
+
+# Local dev / worktree metadata
+.claude/
+dev-config/
+docker-compose*.yml
+
+# Logs and local state
+*.log
+**/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,8 @@ ui/.eslintcache
 ezbeq/ui
 
 .idea
+.claude
+.codebuddy
 ezbeq/VERSION
 out
 t.py

--- a/README.md
+++ b/README.md
@@ -4,6 +4,37 @@ A simple web browser for [beqcatalogue](https://beqcatalogue.readthedocs.io/en/l
 with [minidsp-rs](https://github.com/mrene/minidsp-rs)
 for local remote control of a minidsp or HTP-1.
 
+## Table of Contents
+
+- [Setup](#setup)
+  - [Windows / MacOS](#windows--macos)
+  - [Linux](#linux)
+  - [Installation](#installation)
+    - [Docker](#docker)
+    - [Example Config Files](#example-config-files)
+    - [Using with a Minidsp](#using-with-a-minidsp)
+    - [Using with a Monolith HTP-1](#using-with-a-monolith-htp-1)
+  - [Upgrade](#upgrade)
+- [Scripts (bin/)](#scripts-bin)
+- [How the app is structured](#how-the-app-is-structured)
+- [Running the app](#running-the-app)
+  - [Stub mode — no hardware required](#stub-mode--no-hardware-required)
+  - [Frontend hot-reload (UI development)](#frontend-hot-reload-ui-development)
+  - [Running the tests](#running-the-tests)
+  - [Smoke test](#smoke-test)
+- [Configuration](#configuration)
+  - [Using a custom catalogue](#using-a-custom-catalogue)
+  - [Configuring Devices](#configuring-devices)
+    - [Minidsp](#minidsp)
+    - [Monolith HTP1](#monolith-htp1)
+    - [JRiver Media Center](#jriver-media-center)
+    - [Q-Sys](#q-sys)
+    - [CamillaDSP](#camilladsp)
+- [Starting ezbeq on bootup](#starting-ezbeq-on-bootup)
+- [Verifying MiniDSP Response](#verifying-minidsp-response)
+  - [Quick & Crude](#quick--crude)
+  - [Slower but Accurate](#slower-but-accurate)
+
 # Setup
 
 ## Windows / MacOS
@@ -19,16 +50,30 @@ Use your distro package manager to install python.
 
 ## Installation
 
+ezbeq uses [Poetry](https://python-poetry.org/) for dependency management.
+
+    $ pip install poetry
+    $ git clone https://github.com/3ll3d00d/ezbeq
+    $ cd ezbeq
+    $ poetry install
+
 Example is provided for rpi users
 
     $ ssh pi@myrpi
     $ sudo apt install python3 python3-venv python3-pip libyaml-dev
-    $ mkdir python
-    $ cd python
-    $ python3 -m venv ezbeq
+    $ pip install poetry
+    $ git clone https://github.com/3ll3d00d/ezbeq
     $ cd ezbeq
-    $ . bin/activate
-    $ pip install ezbeq
+    $ poetry install
+
+### Docker
+
+The official ezBEQ docker image is published at https://github.com/3ll3d00d/ezbeq-docker.
+See that project's README for setup instructions, example compose files, and USB device configuration.
+
+#### Running in Docker
+
+Set `EZBEQ_ACCESS_LOG_STDOUT=1` in your container environment to echo every HTTP request to stdout so it appears in `docker compose logs`. This is independent of `accessLogging:` in `ezbeq.yml` (which controls the access log file).
 
 ### Example Config Files
 
@@ -59,23 +104,90 @@ See the configuration section below
 
 ## Upgrade
 
-    $ ssh pi@myrpi
-    $ cd python/ezbeq
-    $ . bin/activate
-    $ pip install --upgrade --force-reinstall ezbeq
+    $ cd ezbeq
+    $ git pull
+    $ poetry install
 
 then restart the app
 
-## Running the app manually
+## Scripts (bin/)
 
-    $ ssh pi@myrpi
-    $ cd python/ezbeq
-    $ . bin/activate
-    $ ./bin/ezbeq
-      Loading config from /home/pi/.ezbeq/ezbeq.yml
-      2021-01-16 08:43:15,374 - twisted - INFO - __init__ - Serving ui from /home/pi/python/ezbeq/lib/python3.8/site-packages/ezbeq/ui
+| Script | Purpose |
+|--------|---------|
+| [`bin/run-server`](#running-the-app) | Start the server with real hardware |
+| [`bin/run-server-stub`](#stub-mode--no-hardware-required) | Start with a simulated device — no hardware needed |
+| [`bin/run-ui-dev`](#frontend-hot-reload-ui-development) | Hot-reload UI dev mode (Vite + Python backend) |
+| [`bin/run-tests`](#running-the-tests) | Run pytest suite + smoke test |
+| [`bin/smoke-test`](#smoke-test) | HTTP smoke test against a running server |
 
-Now open http://youripaddress:8080/index.html in your browser
+## How the app is structured
+
+ezbeq is a single Python server (Twisted) that does two things:
+
+1. **Serves the REST API** — `/api/...` routes handled by Flask
+2. **Serves the React UI** — pre-built static files from `ezbeq/ui/`
+
+The UI source lives in `ui/` and is built with [Vite](https://vitejs.dev/) /
+[Yarn](https://yarnpkg.com/). Running `yarn build` compiles it into
+`ezbeq/ui/`, which the Python server then picks up automatically. The Docker
+image ships with the UI pre-built.
+
+## Running the app
+
+    $ cd ezbeq
+    $ bin/run-server
+
+Then open http://localhost:8080 in your browser.
+
+> **Note:** `bin/run-server` requires the `minidsp` binary in your PATH.
+> Install it from [minidsp-rs releases](https://github.com/mrene/minidsp-rs/releases).
+> To run without hardware, see *Stub mode* below.
+
+### Stub mode — no hardware required
+
+Simulates a MiniDSP 2x4HD in memory. No `minidsp` binary or physical device
+needed. Builds the UI automatically if it hasn't been built yet.
+
+    $ bin/run-server-stub
+
+Then open http://localhost:8080.
+
+### Frontend hot-reload (UI development)
+
+For iterating on the React UI without rebuilding after every change:
+
+    $ bin/run-ui-dev
+
+This starts **two** processes and wires them together:
+
+| Process | URL | Purpose |
+|---------|-----|---------|
+| Python backend (stub) | http://localhost:8080 | API + WebSocket |
+| Vite dev server | http://localhost:5174 | UI with hot-reload |
+
+Open **http://localhost:5174** in your browser. Edits to files under `ui/src/`
+are reflected instantly. The Python backend does not hot-reload; restart the
+script when you change backend code.
+
+> **Requires Node + Yarn.** Node is available via
+> [homebrew](https://formulae.brew.sh/formula/node) (`brew install node`).
+> Yarn is activated via `corepack enable yarn`.
+
+### Running the tests
+
+    $ bin/run-tests
+
+This runs the pytest suite followed by an HTTP smoke test that starts a stub
+server, makes real HTTP requests, and checks the responses.
+
+### Smoke test
+
+`bin/smoke-test` can also be run standalone — useful for checking a server
+that is already running:
+
+    $ bin/smoke-test                  # start a temporary stub server, run checks, stop
+    $ bin/smoke-test --port 9999      # same, but on a custom port
+    $ bin/smoke-test --no-start       # check a server already running on port 8080
 
 ## Configuration
 

--- a/bin/run-server
+++ b/bin/run-server
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec poetry run ezbeq

--- a/bin/run-server-stub
+++ b/bin/run-server-stub
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run ezbeq with a stub device - no hardware or minidsp binary required.
+# Config is written to a temporary directory so it doesn't interfere with
+# your real ~/.ezbeq setup.
+#
+# The React UI is built into ezbeq/ui/ before starting if it isn't already
+# present. Re-run `yarn build` in the ui/ directory any time you change the
+# frontend code.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# ── Build the UI if it hasn't been built yet ──────────────────────────────────
+if [[ ! -f ezbeq/ui/index.html ]]; then
+    echo "UI not built — running yarn build in ui/ ..."
+    (cd ui && yarn install --silent && yarn build)
+    echo
+fi
+
+# ── Write a throw-away config and start the server ───────────────────────────
+STUB_CONFIG_DIR="${TMPDIR:-/tmp}/ezbeq-stub"
+mkdir -p "$STUB_CONFIG_DIR"
+
+cat > "$STUB_CONFIG_DIR/ezbeq.yml" << 'EOF'
+port: 9968
+accessLogging: false
+debugLogging: true
+devices:
+  master:
+    type: minidsp
+    exe: stub
+EOF
+
+echo "Starting ezbeq in stub mode"
+echo "  Config : $STUB_CONFIG_DIR/ezbeq.yml"
+echo "  Open   : http://localhost:9968"
+echo
+EZBEQ_CONFIG_HOME="$STUB_CONFIG_DIR" exec poetry run ezbeq

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+poetry run pytest "$@"
+
+# Run the HTTP smoke test unless pytest args suggest a subset run (e.g. -k, specific file)
+if [[ $# -eq 0 ]]; then
+    echo
+    bin/smoke-test
+fi

--- a/bin/run-ui-dev
+++ b/bin/run-ui-dev
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Hot-reload frontend development mode.
+#
+# Starts two processes:
+#   1. The Python backend (stub device) on port 8080
+#   2. The Vite dev server on port 5174, which proxies /api and /ws to port 8080
+#
+# Open http://localhost:5174 in your browser. The UI auto-reloads on any
+# change to files in ui/src/. The Python server does NOT hot-reload; restart
+# this script when you change backend code.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+STUB_CONFIG_DIR="${TMPDIR:-/tmp}/ezbeq-stub-dev"
+mkdir -p "$STUB_CONFIG_DIR"
+
+cat > "$STUB_CONFIG_DIR/ezbeq.yml" << 'EOF'
+port: 8080
+accessLogging: false
+debugLogging: true
+devices:
+  master:
+    type: minidsp
+    exe: stub
+EOF
+
+cleanup() {
+    echo
+    echo "Shutting down..."
+    kill "$BACKEND_PID" "$VITE_PID" 2>/dev/null || true
+    wait "$BACKEND_PID" "$VITE_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Start the Python backend on port 8080
+echo "Starting Python backend (stub) on port 8080..."
+EZBEQ_CONFIG_HOME="$STUB_CONFIG_DIR" poetry run ezbeq &
+BACKEND_PID=$!
+
+# Wait for backend to be ready
+echo -n "  Waiting for backend"
+for i in $(seq 1 30); do
+    if curl -sf http://localhost:8080/api/1/devices >/dev/null 2>&1; then
+        echo " ready"
+        break
+    fi
+    echo -n "."; sleep 0.3
+done
+
+# Start the Vite dev server
+echo "Starting Vite dev server on port 5174..."
+echo
+echo "  Open   : http://localhost:5174  (hot-reload UI)"
+echo "  API    : http://localhost:8080  (Python backend)"
+echo
+cd ui && yarn install --silent && yarn localdev &
+VITE_PID=$!
+
+wait "$VITE_PID"

--- a/bin/smoke-test
+++ b/bin/smoke-test
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# HTTP smoke test for the ezbeq server.
+# By default starts its own stub server on a temporary port, runs checks, then shuts it down.
+#
+# Usage:
+#   bin/smoke-test                # start stub on port 18080, run checks, stop
+#   bin/smoke-test --port 9999    # same, but on a different port
+#   bin/smoke-test --no-start     # check a server already running on --port (default 8080)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+START_SERVER=true
+PORT=18080
+LOG_FILE=""
+SERVER_PID=""
+PASS=0
+FAIL=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-start) START_SERVER=false; PORT=8080 ;;
+        --port)     PORT="$2"; shift ;;
+        *)          echo "Unknown argument: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+BASE="http://localhost:$PORT"
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; RESET='\033[0m'; BOLD='\033[1m'
+ok()   { echo -e "  ${GREEN}✓${RESET} $*"; (( PASS++ )) || true; }
+fail() { echo -e "  ${RED}✗${RESET} $*"; (( FAIL++ )) || true; }
+info() { echo -e "  ${YELLOW}→${RESET} $*"; }
+
+# ── Port helper ───────────────────────────────────────────────────────────────
+port_in_use() { lsof -ti :"$1" >/dev/null 2>&1; }
+
+kill_port() {
+    local pids; pids=$(lsof -ti :"$1" 2>/dev/null || true)
+    if [[ -n "$pids" ]]; then
+        echo -e "${YELLOW}  Port $1 already in use (pid $pids) — killing...${RESET}"
+        kill $pids 2>/dev/null || true
+        sleep 0.5
+    fi
+}
+
+cleanup() {
+    if [[ -n "$SERVER_PID" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# ── Start server (unless --no-start) ─────────────────────────────────────────
+if $START_SERVER; then
+    kill_port "$PORT"
+    STUB_CONFIG_DIR="${TMPDIR:-/tmp}/ezbeq-smoke-test"
+    LOG_FILE="$STUB_CONFIG_DIR/server.log"
+    mkdir -p "$STUB_CONFIG_DIR"
+    cat > "$STUB_CONFIG_DIR/ezbeq.yml" << EOF
+port: $PORT
+accessLogging: false
+debugLogging: true
+devices:
+  master:
+    type: minidsp
+    exe: stub
+EOF
+    echo -e "${BOLD}Starting stub server on port $PORT...${RESET}"
+    # EZBEQ_ACCESS_LOG_STDOUT=1 makes each HTTP request appear in the server log
+    # (stdout/stderr) in addition to any access.log file.
+    EZBEQ_CONFIG_HOME="$STUB_CONFIG_DIR" EZBEQ_ACCESS_LOG_STDOUT=1 \
+        poetry run ezbeq >"$LOG_FILE" 2>&1 &
+    SERVER_PID=$!
+
+    echo -n "  Waiting for server to be ready"
+    READY=false
+    for i in $(seq 1 40); do
+        if curl -sf "$BASE/api/1/devices" >/dev/null 2>&1; then
+            READY=true; break
+        fi
+        echo -n "."; sleep 0.3
+    done
+    echo
+
+    if ! $READY; then
+        echo -e "${RED}Server did not start in time. Log:${RESET}"
+        cat "$LOG_FILE"
+        exit 1
+    fi
+    echo -e "  ${GREEN}Server ready${RESET} (pid $SERVER_PID, log: $LOG_FILE)\n"
+else
+    if ! port_in_use "$PORT"; then
+        echo -e "${RED}No server found on port $PORT.${RESET}"
+        echo -e "Start one with ${BOLD}bin/run-server-stub${RESET}, or drop --no-start to have this script do it."
+        exit 1
+    fi
+fi
+
+# ── HTTP check helper (GET) ───────────────────────────────────────────────────
+check() {
+    local label="$1" url="$2" expect_status="$3" expect_not="${4:-}" expect_contains="${5:-}"
+
+    echo -e "${CYAN}── $label${RESET}"
+    info "GET $url"
+
+    local tmp; tmp=$(mktemp)
+    local http_status
+    http_status=$(curl -s -o "$tmp" -w "%{http_code}" "$url" 2>/dev/null) || true
+    local body; body=$(cat "$tmp"); rm -f "$tmp"
+
+    if [[ "$http_status" == "000" ]]; then
+        fail "HTTP $http_status — connection refused (is the server running on port $PORT?)"
+    elif [[ "$http_status" == "$expect_status" ]]; then
+        ok "HTTP $http_status"
+    else
+        fail "HTTP $http_status (expected $expect_status)"
+    fi
+
+    if [[ -n "$expect_not" ]]; then
+        if echo "$body" | grep -q "$expect_not"; then
+            fail "Response body contains '$expect_not'"
+        else
+            ok "Response body does not contain '$expect_not'"
+        fi
+    fi
+
+    if [[ -n "$expect_contains" ]]; then
+        if echo "$body" | grep -q "$expect_contains"; then
+            ok "Response body contains '$expect_contains'"
+        else
+            fail "Response body missing '$expect_contains'"
+        fi
+    fi
+
+    # Pretty-print JSON, or show a trimmed preview for non-JSON responses
+    if echo "$body" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+        info "Body (JSON):"
+        local pretty; pretty=$(echo "$body" | python3 -m json.tool 2>/dev/null)
+        local lines; lines=$(echo "$pretty" | wc -l)
+        echo "$pretty" | head -30 | sed 's/^/    /'
+        if [[ $lines -gt 30 ]]; then
+            echo "    ... ($((lines - 30)) more lines)"
+        fi
+    else
+        local preview; preview=$(echo "$body" | tr -d '\n' | cut -c1-200)
+        info "Body: $preview"
+    fi
+    echo
+}
+
+# ── Non-GET HTTP check helper ─────────────────────────────────────────────────
+request_check() {
+    local label="$1" method="$2" url="$3" expect_status="$4" data="${5:-}"
+
+    echo -e "${CYAN}── $label${RESET}"
+    info "$method $url"
+
+    local tmp; tmp=$(mktemp)
+    local http_status
+    local curl_args=(-s -X "$method" -o "$tmp" -w "%{http_code}")
+    if [[ -n "$data" ]]; then
+        curl_args+=(-H "Content-Type: application/json" -d "$data")
+    fi
+    http_status=$(curl "${curl_args[@]}" "$url" 2>/dev/null) || true
+    local body; body=$(cat "$tmp"); rm -f "$tmp"
+
+    if [[ "$http_status" == "000" ]]; then
+        fail "HTTP $http_status — connection refused (is the server running on port $PORT?)"
+    elif [[ "$http_status" == "$expect_status" ]]; then
+        ok "HTTP $http_status"
+    else
+        fail "HTTP $http_status (expected $expect_status)"
+    fi
+
+    if echo "$body" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+        info "Body (JSON):"
+        echo "$body" | python3 -m json.tool 2>/dev/null | head -20 | sed 's/^/    /'
+    fi
+    echo
+}
+
+# ── Log check helper (only meaningful in self-start mode) ────────────────────
+log_check() {
+    local label="$1" pattern="$2"
+
+    echo -e "${CYAN}── $label${RESET}"
+    if [[ -z "$LOG_FILE" ]]; then
+        info "Skipped (no log file — only in self-start mode)"
+        echo; return
+    fi
+    if grep -q "$pattern" "$LOG_FILE"; then
+        ok "Log contains: $pattern"
+        # Show the matching line(s) for confirmation
+        grep "$pattern" "$LOG_FILE" | head -3 | sed 's/^/    /'
+    else
+        fail "Log missing: $pattern"
+        info "Last 15 log lines:"
+        tail -15 "$LOG_FILE" | sed 's/^/    /'
+    fi
+    echo
+}
+
+# ── HTTP checks ───────────────────────────────────────────────────────────────
+echo -e "${BOLD}Smoke-testing $BASE${RESET}\n"
+
+check "Root / (expect 200 with React app)" \
+    "$BASE/"              "200" "Processing Failed"
+
+check "GET /api/1/devices — expect device state" \
+    "$BASE/api/1/devices" "200" "Processing Failed" '"masterVolume"'
+
+check "GET /api/1/version — expect version field" \
+    "$BASE/api/1/version" "200" "Processing Failed" '"version"'
+
+check "GET /static/foo.js (not built — expect 404, not a crash)" \
+    "$BASE/static/foo.js" "404" "Processing Failed"
+
+check "GET /somepage (unknown path — with UI built, React SPA serves index.html as 200)" \
+    "$BASE/somepage"      "200" "Processing Failed"
+
+check "GET /ws (WebSocket endpoint — expect Autobahn info page)" \
+    "$BASE/ws"            "200" "Processing Failed"
+
+# Clear a filter slot — this drives a full round-trip through the minidsp layer
+# (stub mode) so we can verify the debug logging output below.
+request_check "DELETE /api/1/devices/master/filter/1 — clear slot (exercises minidsp stub)" \
+    DELETE "$BASE/api/1/devices/master/filter/1" "200"
+
+# ── Log checks ────────────────────────────────────────────────────────────────
+echo -e "${BOLD}Log checks${RESET}\n"
+
+log_check "Access log echoed to stdout (EZBEQ_ACCESS_LOG_STDOUT)" \
+    "ezbeq.access"
+
+log_check "minidsp stub runner invoked (debugLogging=true)" \
+    "MinidspStubRunner"
+
+log_check "Command count and timing logged" \
+    "commands to slot"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+if [[ $FAIL -gt 0 ]]; then
+    echo -e "${BOLD}Results: ${GREEN}$PASS passed${RESET}, ${RED}$FAIL failed${RESET}"
+else
+    echo -e "${BOLD}Results: ${GREEN}$PASS passed, $FAIL failed${RESET}"
+fi
+
+# ── Server log (always shown so failures are diagnosable) ─────────────────────
+if [[ -n "$LOG_FILE" ]]; then
+    echo
+    echo -e "${BOLD}═══ Server log ($LOG_FILE) ═══${RESET}"
+    cat "$LOG_FILE"
+fi
+
+[[ $FAIL -eq 0 ]]

--- a/ezbeq/apis/devices.py
+++ b/ezbeq/apis/devices.py
@@ -336,6 +336,10 @@ slot_model_v3 = v3_api.model('SlotV3', {
                          description='(Optional) gains to set on the specified input channels (minidsp, camilladsp)'),
     'mutes': fields.List(fields.Nested(mute_model_v3), required=False,
                          description='(Optional) allows each input channel to be muted or unmuted individually (minidsp, camilladsp)'),
+    'outputGains': fields.List(fields.Nested(gain_model_v3), required=False,
+                               description='(Optional) gains to set on the specified output channels (minidsp)'),
+    'outputMutes': fields.List(fields.Nested(mute_model_v3), required=False,
+                               description='(Optional) allows each output channel to be muted or unmuted individually (minidsp)'),
     'entry': fields.String(required=False, description='(Optional) Accepts value from either the id or digest fields')
 })
 

--- a/ezbeq/apis/devices.py
+++ b/ezbeq/apis/devices.py
@@ -274,7 +274,7 @@ class DevicesV2(Resource):
         from ezbeq import to_millis
         start = time.time()
         v = {n: d.serialise() for n, d in self.__bridge.all_devices(refresh=True).items()}
-        logger.info(f'Loaded device state in {to_millis(start, time.time())}ms')
+        logger.debug(f'Loaded device state in {to_millis(start, time.time())}ms')
         return v
 
 
@@ -312,9 +312,9 @@ class DeviceV2(Resource):
                 slot['gains'] = [{'id': str(i + 1), 'value': v} for i, v in enumerate(slot['gains'])]
             if 'mutes' in slot:
                 slot['mutes'] = [{'id': str(i + 1), 'value': v} for i, v in enumerate(slot['mutes'])]
-        logger.info(f"PATCHing {device_name} with {payload}")
+        logger.debug(f"PATCHing {device_name} with {payload}")
         if not self.__bridge.update(device_name, payload):
-            logger.info(f"PATCH {device_name} was a nop")
+            logger.debug(f"PATCH {device_name} was a nop")
         return self.__bridge.state(device_name).serialise()
 
 
@@ -358,13 +358,13 @@ class DeviceV3(Resource):
     @v3_api.expect(device_model_v3, validate=True)
     def patch(self, device_name: str) -> tuple[dict, int]:
         payload = request.get_json()
-        logger.info(f"PATCHing {device_name} with {payload}")
+        logger.debug(f"PATCHing {device_name} with {payload}")
         try:
             updated = self.__bridge.update(device_name, payload)
             if updated:
                 logger.info(f"PATCHed {device_name}")
             else:
-                logger.info(f"PATCH {device_name} was a nop")
+                logger.debug(f"PATCH {device_name} was a nop")
         except UnableToPatchDeviceError as e:
             logger.exception(f'PATCH {device_name} failure')
             return {'message': f'Update failed : {e.msg}'}, e.code

--- a/ezbeq/apis/version.py
+++ b/ezbeq/apis/version.py
@@ -9,6 +9,14 @@ class Version(Resource):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__v = kwargs['version'].strip()
+        gi = kwargs.get('git_info', {})
+        self.__branch = gi.get('branch')
+        self.__sha = gi.get('sha')
 
     def get(self):
-        return {'version': self.__v}
+        result = {'version': self.__v}
+        if self.__branch:
+            result['branch'] = self.__branch
+        if self.__sha:
+            result['sha'] = self.__sha
+        return result

--- a/ezbeq/apis/whatsnew.py
+++ b/ezbeq/apis/whatsnew.py
@@ -1,0 +1,35 @@
+import logging
+import time
+
+from flask_restx import Resource, reqparse, Namespace
+
+from ezbeq.catalogue import CatalogueProvider
+
+logger = logging.getLogger('ezbeq.catalogue')
+
+api = Namespace('1/whats-new', description='Returns recently added or updated BEQ entries')
+
+TWO_WEEKS_SECONDS = 2 * 7 * 24 * 60 * 60
+
+
+@api.route('')
+class WhatsNew(Resource):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__provider: CatalogueProvider = kwargs['catalogue']
+        self.__parser = reqparse.RequestParser()
+        self.__parser.add_argument('since', type=int)
+        self.__parser.add_argument('limit', type=int, default=50)
+
+    @api.param('since', 'Unix timestamp (seconds); entries created or updated after this time are returned. Defaults to 2 weeks ago.')
+    @api.param('limit', 'Max results (default 50)')
+    def get(self):
+        args = self.__parser.parse_args()
+        since = args.get('since')
+        if since is None:
+            since = int(time.time() - TWO_WEEKS_SECONDS)
+        limit = args.get('limit')
+        if limit is None:
+            limit = 50
+        return self.__provider.whats_new(since, limit)

--- a/ezbeq/apis/ws.py
+++ b/ezbeq/apis/ws.py
@@ -66,7 +66,7 @@ class WsProtocol(WebSocketServerProtocol):
                 self.factory.register_for_levels(device_name, self)
             elif s.startswith(LOAD_CATALOGUE_CMD):
                 self.factory.send_catalogue(self)
-        except:
+        except Exception as e:
             logger.exception('Message received failure')
 
 

--- a/ezbeq/apis/ws.py
+++ b/ezbeq/apis/ws.py
@@ -47,10 +47,10 @@ T = TypeVar("T", bound=WsServerFactory)
 class WsProtocol(WebSocketServerProtocol):
 
     def onConnect(self, request):
-        logger.info(f"Client connecting: {request.peer}")
+        logger.debug(f"Client connecting: {request.peer}")
 
     def onOpen(self):
-        logger.info("WebSocket connection open")
+        logger.debug("WebSocket connection open")
         self.factory.register(self)
 
     def onClose(self, was_clean, code, reason):
@@ -60,7 +60,7 @@ class WsProtocol(WebSocketServerProtocol):
     def onMessage(self, payload, is_binary):
         try:
             s = payload.decode('utf-8')
-            logger.info(f"Received '{s}'")
+            logger.debug(f"Received '{s}'")
             if s.startswith(SUBSCRIBE_LEVELS_CMD):
                 device_name = s[len(SUBSCRIBE_LEVELS_CMD) + 1:].rstrip()
                 self.factory.register_for_levels(device_name, self)
@@ -96,7 +96,7 @@ class AutobahnWsServerFactory(WsServerFactory, WebSocketServerFactory):
 
     def register(self, client: WsProtocol):
         if client not in self.__clients:
-            logger.info(f"Registered client {client.peer}")
+            logger.debug(f"Registered client {client.peer}")
             self.__clients.append(client)
             if self.__meta_provider:
                 msg = self.__meta_provider()
@@ -107,7 +107,7 @@ class AutobahnWsServerFactory(WsServerFactory, WebSocketServerFactory):
                 if msg:
                     client.sendMessage(msg.encode('utf8'), isBinary=False)
         else:
-            logger.info(f"Ignoring duplicate client {client.peer}")
+            logger.debug(f"Ignoring duplicate client {client.peer}")
 
     def send_catalogue(self, client: WsProtocol):
         if client not in self.__clients:
@@ -118,7 +118,7 @@ class AutobahnWsServerFactory(WsServerFactory, WebSocketServerFactory):
 
             def encode_and_send(msg):
                 if msg:
-                    logger.info(f'Sending catalogue msg (len {len(msg)}b)')
+                    logger.debug(f'Sending catalogue msg (len {len(msg)}b)')
                     client.sendMessage(msg.encode('utf8'), isBinary=False)
 
             self.__catalogue_loader(encode_and_send)
@@ -128,7 +128,7 @@ class AutobahnWsServerFactory(WsServerFactory, WebSocketServerFactory):
     def register_for_levels(self, device: str, client: WsProtocol):
         if device in self.__levels_provider:
             if client in self.__clients:
-                logger.info(f"Removing client {client.peer} from broadcast on level subscription for {device}")
+                logger.debug(f"Removing client {client.peer} from broadcast on level subscription for {device}")
                 self.__clients.remove(client)
             # make sure the device is known
             _ = self.__levels_client[device]
@@ -137,7 +137,7 @@ class AutobahnWsServerFactory(WsServerFactory, WebSocketServerFactory):
                     if client in v:
                         logger.warning(f"Client {client.peer} already subscribed to levels for {device}")
                     else:
-                        logger.info(f"Client {client.peer} subscribed to levels for {device}")
+                        logger.debug(f"Client {client.peer} subscribed to levels for {device}")
                         v.append(client)
             self.__levels_provider[device]()
         else:
@@ -147,23 +147,23 @@ class AutobahnWsServerFactory(WsServerFactory, WebSocketServerFactory):
         for k, v in self.__levels_client.items():
             try:
                 v.remove(client)
-                logger.info(f"Client {client.peer} unsubscribed from levels for {k}")
+                logger.debug(f"Client {client.peer} unsubscribed from levels for {k}")
             except ValueError:
                 pass
 
     def unregister(self, client: WsProtocol):
         if client in self.__clients:
-            logger.info(f"Unregistering client {client.peer}")
+            logger.debug(f"Unregistering client {client.peer}")
             self.__clients.remove(client)
         else:
             found = False
             for device, clients in self.__levels_client.items():
                 if client in clients:
                     found = True
-                    logger.info(f"Unregistering {device} levels client {client.peer}")
+                    logger.debug(f"Unregistering {device} levels client {client.peer}")
                     clients.remove(client)
             if not found:
-                logger.info(f"Ignoring unregistered client {client.peer}")
+                logger.debug(f"Ignoring unregistered client {client.peer}")
 
     def broadcast(self, msg: str):
         logger.debug(f"Broadcasting {msg}")
@@ -183,7 +183,7 @@ class AutobahnWsServerFactory(WsServerFactory, WebSocketServerFactory):
                 self.unregister(c)
             return len(disconnected_clients) < len(clients)
         else:
-            logger.info(f"No devices connected, ignoring {msg}")
+            logger.debug(f"No devices connected, ignoring {msg}")
             return False
 
     def send_levels(self, device: str, msg: str):

--- a/ezbeq/apis/ws.py
+++ b/ezbeq/apis/ws.py
@@ -210,6 +210,9 @@ class WsServer(abc.ABC, Generic[T]):
     def broadcast(self, msg: str):
         self.factory.broadcast(msg)
 
+    def broadcast_error(self, msg: str, persistent: bool = False):
+        self.broadcast(json.dumps({'message': 'Error', 'data': msg, 'persistent': persistent}))
+
     def levels(self, device: str, levels: dict) -> bool:
         return self.factory.send_levels(device, json.dumps({'message': 'Levels', 'data': levels}))
 

--- a/ezbeq/catalogue.py
+++ b/ezbeq/catalogue.py
@@ -125,7 +125,7 @@ class CatalogueEntry:
         y = 0
         try:
             y = int(vals.get(YEAR, 0))
-        except:
+        except ValueError as e:
             logger.error(f"Invalid year {vals.get(YEAR, 0)} in {self.title}")
         self.year = y
 
@@ -171,7 +171,7 @@ class CatalogueEntry:
         self.formatted_title = self.__format_title()
         try:
             r = int(vals.get(RUNTIME, 0))
-        except:
+        except ValueError as e:
             logger.error(f"Invalid runtime {vals.get('runtime', 0)} in {self.title}")
             r = 0
         self.runtime = r
@@ -180,7 +180,7 @@ class CatalogueEntry:
             v = vals['mv']
             try:
                 self.mv_adjust = float(v)
-            except:
+            except (ValueError, TypeError) as e:
                 logger.error(f"Unknown mv_adjust value in {self.title} - {vals['mv']}")
         self.freshness = compute_freshness(self.created_at, self.updated_at)
 
@@ -439,7 +439,7 @@ class Catalogues:
                             catalogue = self.__insert_catalogue(f.read().strip(), meta_only=loaded == 2)
                             if catalogue:
                                 catalogues.append(catalogue)
-                except:
+                except Exception as e:
                     logger.exception(
                         f'[{self.__db}] Failed to load catalogue at startup from {self.__catalogue_file}')
         return catalogues
@@ -847,8 +847,8 @@ class DatabaseDownloader:
                     return True
                 else:
                     logger.warning(f"Unable to download catalogue, response is {r.status_code}")
-            except:
-                logger.exception("Unable to download catalogue, unexpected error")
+            except Exception as e:
+                logger.exception(f"Unable to download catalogue, unexpected error")
         else:
             logger.info(f"No reload required {remote_version} vs {self.__cached_version}")
         return False
@@ -865,7 +865,7 @@ class DatabaseDownloader:
                 return txt.strip() if txt else txt
             else:
                 logger.warning(f"Unable to get {self.__version_url}, response was {r.status_code}")
-        except:
+        except Exception as e:
             logger.exception(f"Failed to get {self.__version_url}")
         return None
 

--- a/ezbeq/catalogue.py
+++ b/ezbeq/catalogue.py
@@ -344,7 +344,7 @@ class Catalogues:
                 'data': self.__fetch_entries(select, UI_FIELDS, limit, offset)
             }, ensure_ascii=False)
             end = time.time()
-            logger.info(f'Loaded chunk from {offset} to {next_offset} in {to_millis(begin, end)}ms')
+            logger.debug(f'Loaded chunk from {offset} to {next_offset} in {to_millis(begin, end)}ms')
             vals = {'count': count, 'limit': self.__chunk_sizes[1], 'offset': next_offset, 'start': start}
             from twisted.internet import threads
             threads.deferToThread(lambda: self.__load_next_chunk(publisher, version, **vals)).addCallback(publisher)
@@ -608,7 +608,7 @@ class Catalogues:
                 after = time.time()
                 logger.info(f'Vacuumed DB in {to_millis(before, after)} ms')
             else:
-                logger.info('Nothing to prune')
+                logger.debug(f'Nothing to prune')
 
     def refresh_if_stale(self):
         if not self.loaded or self.latest.stale:
@@ -710,7 +710,7 @@ class Catalogues:
             res = cur.execute(select)
             rows = res.fetchmany(size=limit if limit else 20000)
             after_load = time.time()
-            logger.info(f'Loaded {len(rows)} entries from db in {to_millis(before, after_load)} ms')
+            logger.debug(f'Loaded {len(rows)} entries from db in {to_millis(before, after_load)} ms')
             for row in rows:
                 vals = {k: v for k, v in {fields[i]: reformat(i, r) for i, r in enumerate(row)}.items() if v}
                 if UPDATED_AT in vals and CREATED_AT in vals:
@@ -724,8 +724,7 @@ class Catalogues:
                     vals['mvAdjust'] = vals[MV_ADJUST]
                 entries.append(vals)
             after = time.time()
-            logger.info(
-                f'Parsed {len(entries)} entries from db in {to_millis(after_load, after)} ms, total time {to_millis(before, after)} ms')
+            logger.debug(f'Parsed {len(entries)} entries from db in {to_millis(after_load, after)} ms, total time {to_millis(before, after)} ms')
             return entries
 
 
@@ -795,7 +794,7 @@ class CatalogueProvider:
         return finder(val)
 
     def __load_meta_if_present(self, meta_type: str):
-        logger.info(f'Loading meta for {meta_type}')
+        logger.debug(f'Loading meta for {meta_type}')
         from twisted.internet import reactor
         reactor.callLater(0, self.__catalogues.refresh_if_stale)
         latest = self.__catalogues.latest
@@ -848,7 +847,7 @@ class DatabaseDownloader:
                 else:
                     logger.warning(f"Unable to download catalogue, response is {r.status_code}")
             except Exception as e:
-                logger.exception(f"Unable to download catalogue, unexpected error")
+                logger.exception("Unable to download catalogue, unexpected error")
         else:
             logger.info(f"No reload required {remote_version} vs {self.__cached_version}")
         return False

--- a/ezbeq/catalogue.py
+++ b/ezbeq/catalogue.py
@@ -634,6 +634,20 @@ class Catalogues:
         else:
             return None
 
+    def whats_new(self, since: int, limit: int = 50) -> list[dict]:
+        catalogue = self.latest
+        if not catalogue:
+            return []
+        fields = [ID, FORMATTED_TITLE, YEAR, AUTHOR, CONTENT_TYPE, AUDIO_TYPES, CREATED_AT, UPDATED_AT]
+        fields_str = ', '.join(fields)
+        sql = (
+            f"SELECT {fields_str} FROM catalogue_entry "
+            f"WHERE version = '{catalogue.version}' "
+            f"AND ({CREATED_AT} >= {since} OR {UPDATED_AT} >= {since}) "
+            f"ORDER BY MAX({CREATED_AT}, {UPDATED_AT}) DESC"
+        )
+        return self.__fetch_entries(sql, fields, limit)
+
     def search(self, authors: list[str], years: list[int], audio_types: list[str], content_types: list[str],
                tmdb_id: str, text: str | None, audio_codecs: list[str], audio_channel_counts: list[str],
                fields: list[str], limit: int | None) -> list[dict]:
@@ -772,6 +786,11 @@ class CatalogueProvider:
     @property
     def years(self) -> list[str]:
         return self.__load_meta_if_present(YEAR)
+
+    def whats_new(self, since: int, limit: int = 50) -> list[dict]:
+        from twisted.internet import reactor
+        reactor.callLater(0, self.__catalogues.refresh_if_stale)
+        return self.__catalogues.whats_new(since, limit)
 
     def search(self, authors: list[str], years: list[int], audio_types: list[str], content_types: list[str],
                tmdb_id: str, text: str | None, audio_codecs: list[str], audio_channel_counts: list[str],

--- a/ezbeq/config.py
+++ b/ezbeq/config.py
@@ -29,6 +29,19 @@ class Config:
         if not os.path.exists(d):
             os.makedirs(d)
 
+    def as_dict(self) -> dict:
+        """Return the raw config dict (without internal make_runner callables)."""
+        result = {}
+        for k, v in self.config.items():
+            if k == 'devices':
+                result['devices'] = {
+                    name: {dk: dv for dk, dv in dev.items() if not callable(dv)}
+                    for name, dev in v.items()
+                }
+            else:
+                result[k] = v
+        return result
+
     @property
     def enable_metrics(self) -> bool:
         return self.__enable_metrics
@@ -52,9 +65,9 @@ class Config:
     @property
     def is_debug_logging(self):
         """
-        :return: if debug logging mode is on, defaults to False.
+        :return: if debug logging mode is on, defaults to True.
         """
-        return self.config.get('debugLogging', False)
+        return self.config.get('debugLogging', True)
 
     @property
     def is_access_logging(self):
@@ -170,8 +183,35 @@ class Config:
         return logger
 
     def create_minidsp_runner(self, exe: str, options: str):
+        """
+        Build the command object used to invoke the minidsp-rs binary.
+
+        If exe is 'stub', returns a MinidspStubRunner that simulates a MiniDSP
+        2x4HD in memory — no hardware or binary required.  Otherwise resolves
+        the named executable via plumbum and applies any extra CLI options.
+        Exits with a helpful message if the binary cannot be found.
+        """
+        if exe == 'stub':
+            from ezbeq.minidsp import MinidspStubRunner
+            return MinidspStubRunner()
         from plumbum import local
-        cmd = local[exe]
+        from plumbum.commands.processes import CommandNotFound
+        try:
+            cmd = local[exe]
+        except CommandNotFound:
+            raise SystemExit(
+                f"Error: '{exe}' binary not found in PATH.\n"
+                f"\n"
+                f"To connect to real hardware, install minidsp-rs:\n"
+                f"  https://github.com/mrene/minidsp-rs/releases\n"
+                f"\n"
+                f"To run without hardware (stub mode), use:\n"
+                f"  bin/run-server-stub\n"
+                f"  (or set exe: stub in your ezbeq.yml)\n"
+                f"\n"
+                f"Or run via Docker (no local deps required):\n"
+                f"  https://github.com/3ll3d00d/ezbeq-docker"
+            )
         return cmd[options.split(' ')] if options else cmd
 
     def create_ws_client(self, ip: str, port: int, listener):
@@ -193,6 +233,28 @@ class Config:
         return v
 
     @property
+    def git_info(self) -> dict:
+        import subprocess
+        result = {
+            'branch': os.environ.get('GIT_BRANCH'),
+            'sha': os.environ.get('GIT_SHA'),
+        }
+        if result['branch'] and result['sha']:
+            return result
+        try:
+            result['sha'] = subprocess.check_output(
+                ['git', 'rev-parse', '--short', 'HEAD'],
+                stderr=subprocess.DEVNULL, cwd=os.path.dirname(__file__)
+            ).decode().strip()
+            result['branch'] = subprocess.check_output(
+                ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+                stderr=subprocess.DEVNULL, cwd=os.path.dirname(__file__)
+            ).decode().strip()
+        except Exception:
+            pass
+        return result
+
+    @property
     def load_catalogue_at_startup(self):
         return False
 
@@ -209,7 +271,7 @@ class Config:
             else:
                 mmap_mb = 0
         except Exception as e:
-            self.logger.exception(f'Unable to get total physical memory, will default to 0')
+            self.logger.exception('Unable to get total physical memory, will default to 0')
         return self.config.get('db_mmap_mb', mmap_mb)
 
     @staticmethod

--- a/ezbeq/config.py
+++ b/ezbeq/config.py
@@ -208,8 +208,8 @@ class Config:
                 mmap_mb = 50
             else:
                 mmap_mb = 0
-        except:
-            self.logger.exception('Unable to get total physical memory, will default to 0')
+        except Exception as e:
+            self.logger.exception(f'Unable to get total physical memory, will default to 0')
         return self.config.get('db_mmap_mb', mmap_mb)
 
     @staticmethod

--- a/ezbeq/device.py
+++ b/ezbeq/device.py
@@ -225,12 +225,12 @@ class PersistentDevice(Device, ABC, Generic[T]):
                 try:
                     with open(self.__file_name) as f:
                         cached_state = json.load(f)
-                    logger.info(f"Loaded {cached_state} from {self.__file_name}")
+                    logger.debug(f"Loaded {cached_state} from {self.__file_name}")
                     self._current_state = self._merge_state(self._current_state, cached_state)
                 except Exception:
                     logger.exception(f'Failed to load content from {self.__file_name}')
             else:
-                logger.info(f"No cached state found at {self.__file_name}")
+                logger.debug(f"No cached state found at {self.__file_name}")
             if refresh is False:
                 self.__ws_server.factory.init_state_provider(self.__get_state_msg)
                 self.__hydrated = True

--- a/ezbeq/htp1.py
+++ b/ezbeq/htp1.py
@@ -152,7 +152,7 @@ class Htp1(PersistentDevice[Htp1State]):
         version = version[1:] if version[0] == 'v' or version[0] == 'V' else version
         try:
             self.__supports_shelf = semver.parse_version_info(version) > semver.parse_version_info('1.4.0')
-        except:
+        except ValueError as e:
             logger.error(f"Unable to parse version {mso['versions']['swVer']}, will not send shelf filters")
             self.__supports_shelf = False
         if not self.__supports_shelf:

--- a/ezbeq/main.py
+++ b/ezbeq/main.py
@@ -77,7 +77,7 @@ def main(args=None):
     logger.warning('=' * 60)
     gi = cfg.git_info
     git_str = f"  git: {gi['branch']}@{gi['sha']}" if gi.get('branch') or gi.get('sha') else ''
-    logger.warning(f'  ezbeq  |  port: {cfg.port}  |  config: {cfg.config_path}{git_str}')
+    logger.warning(f'  ezbeq  |  http://localhost:{cfg.port}  |  config: {cfg.config_path}{git_str}')
     logger.warning(f'  logging: debug={cfg.is_debug_logging}  access={cfg.is_access_logging}')
     for dev_name, dev_cfg in raw.get('devices', {}).items():
         dev_type = dev_cfg.get('type', '?')

--- a/ezbeq/main.py
+++ b/ezbeq/main.py
@@ -31,6 +31,7 @@ def create_app(config: Config, ws: WsServer = AutobahnWsServer()) -> tuple[Flask
         'device_bridge': DeviceRepository(config, ws_server, catalogue),
         'catalogue': catalogue,
         'version': config.version,
+        'git_info': config.git_info,
         'load': LoadTester(os.path.join(config.config_path, 'ezbeq.db'))
     }
     app = Flask('ezbeq')
@@ -67,6 +68,30 @@ def main(args=None):
     """ The main routine. """
     cfg = Config('ezbeq')
     logger = cfg.configure_logger()
+
+    # ── Startup summary (logged before anything else so it's at the top) ──────
+    # Use WARNING so these lines always appear on the console regardless of the
+    # debugLogging setting — they're essential for confirming the right device
+    # and mode is active.
+    raw = cfg.as_dict()
+    logger.warning('=' * 60)
+    gi = cfg.git_info
+    git_str = f"  git: {gi['branch']}@{gi['sha']}" if gi.get('branch') or gi.get('sha') else ''
+    logger.warning(f'  ezbeq  |  port: {cfg.port}  |  config: {cfg.config_path}{git_str}')
+    logger.warning(f'  logging: debug={cfg.is_debug_logging}  access={cfg.is_access_logging}')
+    for dev_name, dev_cfg in raw.get('devices', {}).items():
+        dev_type = dev_cfg.get('type', '?')
+        if dev_type == 'minidsp':
+            exe = dev_cfg.get('exe', 'minidsp')
+            opts = dev_cfg.get('options', '')
+            detail = 'STUB (no hardware)' if exe == 'stub' else f'exe={exe}' + (f'  options={opts}' if opts else '')
+            logger.warning(f'  device [{dev_name}]  type=minidsp  {detail}')
+        elif dev_type == 'camilladsp':
+            logger.warning(f'  device [{dev_name}]  type=camilladsp  ip={dev_cfg.get("ip")}:{dev_cfg.get("port")}')
+        else:
+            logger.warning(f'  device [{dev_name}]  type={dev_type}')
+    logger.warning('=' * 60)
+
     app, ws_server = create_app(cfg)
 
     import logging
@@ -103,6 +128,24 @@ def main(args=None):
 
         def getChild(self, path, request):
             return self
+
+    class _NoUIPlaceholder(Resource):
+        """Served at / when the React app has not been built."""
+        isLeaf = True
+
+        def render_GET(self, request):
+            request.setHeader(b'Content-Type', b'text/html; charset=utf-8')
+            return (
+                b'<!DOCTYPE html><html><head><title>ezbeq</title></head><body>'
+                b'<h1>ezbeq</h1>'
+                b'<p>The React UI has not been built. '
+                b'See the <a href="https://github.com/3ll3d00d/ezbeq#installation">README</a> '
+                b'for setup instructions.</p>'
+                b'<hr>'
+                b'<p>API: <a href="/api/1/">/api/1/</a> &nbsp;|&nbsp; '
+                b'Swagger: <a href="/api/doc">/api/doc</a></p>'
+                b'</body></html>'
+            )
 
     class FlaskAppWrapper(Resource):
         """
@@ -153,25 +196,87 @@ def main(args=None):
                 request.postpath.insert(0, path)
                 return self.wsgi
             elif path == b'static':
-                return self.static
+                if hasattr(self, 'static'):
+                    return self.static
             elif path == b'metrics' and cfg.enable_metrics:
                 from prometheus_client.twisted import MetricsResource
                 if not self.metrics:
                     self.metrics = MetricsResource()
                 return self.metrics
             else:
-                return self.react.get_file(path)
+                if hasattr(self, 'react'):
+                    return self.react.get_file(path)
+                # No UI built — serve a helpful placeholder for the root, 404 for everything else
+                if path == b'':
+                    return _NoUIPlaceholder()
+            from twisted.web.resource import NoResource
+            return NoResource('UI not available: the React app has not been built')
 
         def render(self, request):
             return self.wsgi.render(request)
 
+    # Separate logger for access log lines written to stdout, so they can be
+    # filtered independently from the main application log.
+    access_logger = logging.getLogger('ezbeq.access')
+    # When EZBEQ_ACCESS_LOG_STDOUT=1 each request is also echoed to stdout so
+    # it appears in `docker compose logs`.  This is set by default in
+    # docker-compose.dev.yaml for local development.
+    _access_log_stdout = os.environ.get('EZBEQ_ACCESS_LOG_STDOUT', '0').strip() == '1'
+
+    class SafeSite(server.Site):
+        """
+        A Site subclass that handles access log write failures gracefully.
+        Twisted's DailyLogFile can enter a broken state when the log file is deleted
+        externally (e.g. container restart) - the rotation code closes the file handle
+        before renaming it, and if the rename fails the handle stays closed. Subsequent
+        writes then raise ValueError which propagates through request.finish() and leaves
+        HTTP responses in a hung state, locking up the UI.
+
+        When log_to_stdout=True each access log line is also written to the
+        'ezbeq.access' Python logger so it appears on stdout / in docker logs.
+        """
+
+        def __init__(self, resource, access_log_path=None, log_to_stdout=False, **kwargs):
+            super().__init__(resource, **kwargs)
+            self._access_log_path = access_log_path
+            self._log_to_stdout = log_to_stdout
+            if access_log_path is not None:
+                self._reopen_log()
+
+        def _reopen_log(self):
+            from twisted.python.logfile import DailyLogFile
+            try:
+                self.logFile = DailyLogFile.fromFullPath(self._access_log_path)
+                logger.info(f'Access log opened: {self._access_log_path}')
+            except Exception:
+                logger.exception(f'Failed to open access log at {self._access_log_path}, access logging disabled')
+                self.logFile = None
+
+        def log(self, request):
+            try:
+                server.Site.log(self, request)
+            except (ValueError, FileNotFoundError, OSError):
+                logger.warning('Access log write failed, attempting to reopen')
+                if self._access_log_path:
+                    self._reopen_log()
+            if self._log_to_stdout:
+                from twisted.web import http
+                ts = http.datetimeToString()
+                if isinstance(ts, bytes):
+                    ts = ts.decode('utf-8', errors='replace')
+                line = self._logFormatter(ts, request)
+                if isinstance(line, bytes):
+                    line = line.decode('utf-8', errors='replace')
+                access_logger.info(line)
+
     if cfg.is_access_logging is True:
-        site = server.Site(FlaskAppWrapper(), logPath=path.join(cfg.config_path, 'access.log').encode())
+        site = SafeSite(FlaskAppWrapper(),
+                        access_log_path=path.join(cfg.config_path, 'access.log'),
+                        log_to_stdout=_access_log_stdout)
     else:
-        site = server.Site(FlaskAppWrapper())
+        site = SafeSite(FlaskAppWrapper(), log_to_stdout=_access_log_stdout)
     endpoint = endpoints.TCP4ServerEndpoint(reactor, cfg.port, interface='0.0.0.0')
     endpoint.listen(site)
-    logger.info(f'Listening on port: {cfg.port}')
     reactor.run()
 
 

--- a/ezbeq/main.py
+++ b/ezbeq/main.py
@@ -9,7 +9,7 @@ from flask_compress import Compress
 from flask_restx import Api
 
 from ezbeq.apis import search, version, devices, authors, audiotypes, years, contenttypes, languages, meta, \
-    catalogue as cat_api, diagnostics, load
+    catalogue as cat_api, diagnostics, load, whatsnew
 from ezbeq.apis.ws import WsServer, AutobahnWsServer
 from ezbeq.catalogue import CatalogueProvider, LoadTester
 from ezbeq.config import Config
@@ -59,6 +59,7 @@ def create_app(config: Config, ws: WsServer = AutobahnWsServer()) -> tuple[Flask
     decorate_ns(languages.api)
     decorate_ns(meta.api)
     decorate_ns(cat_api.api)
+    decorate_ns(whatsnew.api)
     if tracemalloc.is_tracing():
         decorate_ns(diagnostics.api)
     return app, ws_server

--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -535,7 +535,7 @@ class Minidsp(PersistentDevice[MinidspState]):
                 return MinidspState(self.name, self.__descriptor, **values)
             else:
                 logger.error(f"[{self.name}] No output returned from device")
-        except:
+        except Exception as e:
             logger.exception(f"[{self.name}] Unable to parse device state {output}")
         return None
 
@@ -783,7 +783,7 @@ class Minidsp(PersistentDevice[MinidspState]):
                 'ts': ts,
                 'levels': format_levels(levels)
             }
-        except:
+        except Exception as e:
             logger.exception(f"[{self.name}] Unable to load levels {lines}")
             return {}
 
@@ -1035,7 +1035,7 @@ class MinidspRsProtocol(WebSocketClientProtocol):
             logger.debug(f"[{self.factory.device_id}] Received {msg}")
             try:
                 self.factory.listener.on_ws_message(json.loads(msg))
-            except:
+            except Exception as e:
                 logger.exception(f"[{self.factory.device_id}] Receiving unparseable message {msg}")
 
 

--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -60,16 +60,16 @@ class MinidspState(DeviceState):
     def mute(self) -> bool:
         return self.__mute
 
-    def load(self, slot_id: str, title: str, author: str = None):
+    def load(self, slot_id: str, title: str, author: Optional[str] = None) -> None:
         slot = self.get_slot(slot_id)
         slot.last = title
         slot.last_author = author
         self.activate(slot_id)
 
-    def get_slot(self, slot_id) -> 'MinidspSlotState':
+    def get_slot(self, slot_id: str) -> 'MinidspSlotState':
         return next(s for s in self.__slots if s.slot_id == slot_id)
 
-    def clear(self, slot_id):
+    def clear(self, slot_id: str) -> None:
         slot = self.get_slot(slot_id)
         slot.unmute(None)
         slot.set_gain(None, 0.0)
@@ -77,7 +77,7 @@ class MinidspState(DeviceState):
         slot.last_author = None
         self.activate(slot_id)
 
-    def error(self, slot_id):
+    def error(self, slot_id: str) -> None:
         slot = self.get_slot(slot_id)
         slot.last = 'ERROR'
         slot.last_author = None
@@ -121,7 +121,7 @@ class MinidspState(DeviceState):
 
 class MinidspSlotState(SlotState['MinidspSlotState']):
 
-    def __init__(self, slot_id: str, active: bool, input_channels: int, output_channels: int, slot_name: str = None):
+    def __init__(self, slot_id: str, active: bool, input_channels: int, output_channels: int, slot_name: Optional[str] = None):
         super().__init__(slot_id)
         self.__input_channels = input_channels
         self.__output_channels = output_channels
@@ -192,13 +192,13 @@ class MinidspSlotState(SlotState['MinidspSlotState']):
             'outputs': self.__output_channels,
         }
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         vals = ' '.join([f"{g['id']}: {g['value']:.2f}/{self.mutes[i]['value']}" for i, g in enumerate(self.gains)])
         return f"{super().__repr__()} - {vals}"
 
 
 class PeqRoutes:
-    def __init__(self, name: str, biquads: int, channels: list[int], beq_slots: list[int], groups: list[int] = None):
+    def __init__(self, name: str, biquads: int, channels: list[int], beq_slots: list[int], groups: Optional[List[int]] = None):
         self.name = name
         self.biquads = biquads
         self.channels = channels
@@ -209,7 +209,7 @@ class PeqRoutes:
     def takes_beq(self) -> bool:
         return self.channels and len(self.channels) > 0 and self.beq_slots and len(self.beq_slots) > 0
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.name}"
 
     def __eq__(self, o: object) -> bool:
@@ -230,14 +230,14 @@ class BeqFilterSlot:
         self.channels = channels
         self.group = group
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.name}{self.group if self.group is not None else ''}/{self.idx}/{self.channels}"
 
 
 class BeqFilterAllocator:
 
     def __init__(self, routes: list[PeqRoutes]):
-        self.slots = []
+        self.slots: List[BeqFilterSlot] = []
         for r in routes:
             if r and r.takes_beq:
                 for s in r.beq_slots:
@@ -255,14 +255,14 @@ class BeqFilterAllocator:
     def __len__(self):
         return len(self.slots)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.slots}"
 
 
 class MinidspDescriptor:
 
     def __init__(self, name: str, fs: str, i: PeqRoutes | None = None, xo: PeqRoutes | None = None,
-                 o: PeqRoutes | None = None, extra: list[PeqRoutes] = None, slot_names: dict[str, str] = None):
+                 o: PeqRoutes | None = None, extra: list[PeqRoutes] = None, slot_names: Optional[Dict[str, str]] = None):
         self.name = name
         self.fs = str(int(fs))
         self.input = i
@@ -279,7 +279,7 @@ class MinidspDescriptor:
     def to_allocator(self) -> BeqFilterAllocator:
         return BeqFilterAllocator(self.peq_routes)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = f"{self.name}, fs:{self.fs}"
         if self.input:
             s = f"{s}, inputs: {self.input}"
@@ -298,7 +298,7 @@ def zero_til(count: int) -> list[int]:
 
 class Minidsp24HD(MinidspDescriptor):
 
-    def __init__(self, slot_names: dict[str, str] = None):
+    def __init__(self, slot_names: Optional[Dict[str, str]] = None):
         super().__init__('2x4HD',
                          '96000',
                          i=PeqRoutes(INPUT_NAME, 10, zero_til(2), zero_til(10)),
@@ -309,7 +309,7 @@ class Minidsp24HD(MinidspDescriptor):
 
 class Minidsp812CDSP(MinidspDescriptor):
 
-    def __init__(self, slot_names: dict[str, str] = None):
+    def __init__(self, slot_names: Optional[Dict[str, str]] = None):
         super().__init__('8x12CDSP',
                          '192000',
                          i=PeqRoutes(INPUT_NAME, 10, zero_til(6), zero_til(10)),
@@ -320,7 +320,7 @@ class Minidsp812CDSP(MinidspDescriptor):
 
 class MinidspDDRC24(MinidspDescriptor):
 
-    def __init__(self, slot_names: dict[str, str] = None):
+    def __init__(self, slot_names: Optional[Dict[str, str]] = None):
         super().__init__('DDRC24',
                          '48000',
                          xo=PeqRoutes(CROSSOVER_NAME, 4, zero_til(4), [], zero_til(2)),
@@ -330,7 +330,7 @@ class MinidspDDRC24(MinidspDescriptor):
 
 class MinidspHTX(MinidspDescriptor):
 
-    def __init__(self, slot_names: dict[str, str] = None, channels: list[int] = None, use_inputs: bool = False):
+    def __init__(self, slot_names: Optional[Dict[str, str]] = None, channels: list[int] = None, use_inputs: bool = False):
         c = channels if channels is not None else [3]
         if any(ch for ch in c if ch < 0 or ch > 7):
             raise ValueError(f"Invalid channels {c} must be between 0 and 7")
@@ -353,7 +353,7 @@ class MinidspHTX(MinidspDescriptor):
 
 class MinidspDDRC88(MinidspDescriptor):
 
-    def __init__(self, slot_names: dict[str, str] = None, sw_channels: list[int] = None):
+    def __init__(self, slot_names: Optional[Dict[str, str]] = None, sw_channels: Optional[List[int]] = None):
         c = sw_channels if sw_channels is not None else [3]
         if any(ch for ch in c if ch < 0 or ch > 7):
             raise ValueError(f"Invalid channels {c} must be between 0 and 7")
@@ -368,7 +368,7 @@ class MinidspDDRC88(MinidspDescriptor):
 
 class Minidsp410(MinidspDescriptor):
 
-    def __init__(self, slot_names: dict[str, str] = None):
+    def __init__(self, slot_names: Optional[Dict[str, str]] = None):
         super().__init__('4x10',
                          '96000',
                          i=PeqRoutes(INPUT_NAME, 5, zero_til(2), zero_til(5)),
@@ -378,7 +378,7 @@ class Minidsp410(MinidspDescriptor):
 
 class Minidsp1010(MinidspDescriptor):
 
-    def __init__(self, use_xo: bool | int | str, slot_names: dict[str, str] = None):
+    def __init__(self, use_xo: Union[bool, int, str], slot_names: Optional[Dict[str, str]] = None):
         if use_xo is True:
             secondary = {'xo': PeqRoutes(CROSSOVER_NAME, 4, zero_til(8), zero_til(4), groups=[0])}
         elif use_xo is False:
@@ -399,7 +399,7 @@ class Minidsp1010(MinidspDescriptor):
 
 
 def make_peq_layout(cfg: dict, cmd_runner) -> MinidspDescriptor:
-    slot_names: dict[str, str] = {str(k): str(v) for k, v in cfg.get('slotNames', {}).items()}
+    slot_names: Dict[str, str] = {str(k): str(v) for k, v in cfg.get('slotNames', {}).items()}
     if 'device_type' in cfg:
         device_type = cfg['device_type']
         if device_type == '24HD':
@@ -540,14 +540,14 @@ class Minidsp(PersistentDevice[MinidspState]):
         return None
 
     @staticmethod
-    def __as_idx(idx: int | str):
+    def __as_idx(idx: Union[int, str]) -> int:
         return int(idx) - 1
 
-    def __send_cmds(self, target_slot_idx: int | None, cmds: list[str]):
+    def __send_cmds(self, target_slot_idx: Optional[int], cmds: List[str]) -> Any:
         return self.__executor.submit(self.__do_run, cmds, target_slot_idx, self.__slot_change_delay).result(
             timeout=self.__cmd_timeout)
 
-    def activate(self, slot: str):
+    def activate(self, slot: str) -> None:
         def __do_it():
             target_slot_idx = self.__as_idx(slot)
             self.__validate_slot_idx(target_slot_idx)
@@ -557,7 +557,7 @@ class Minidsp(PersistentDevice[MinidspState]):
         self._hydrate_cache_broadcast(__do_it)
 
     @staticmethod
-    def __validate_slot_idx(target_slot_idx):
+    def __validate_slot_idx(target_slot_idx: int) -> None:
         if target_slot_idx < 0 or target_slot_idx > 3:
             raise InvalidRequestError("Slot must be in range 1-4")
 
@@ -663,7 +663,7 @@ class Minidsp(PersistentDevice[MinidspState]):
 
         self._hydrate_cache_broadcast(__do_it)
 
-    def __as_idxes(self, channel, slot):
+    def __as_idxes(self, channel: Optional[int], slot: Optional[str]) -> Tuple[Optional[int], Optional[int]]:
         target_slot_idx = self.__as_idx(slot) if slot else None
         target_channel_idx = self.__as_idx(channel) if channel else None
         return target_channel_idx, target_slot_idx
@@ -765,10 +765,10 @@ class Minidsp(PersistentDevice[MinidspState]):
             any_update = True
         return any_update
 
-    def levels(self) -> dict:
+    def levels(self) -> Dict[str, Any]:
         return self.__executor.submit(self.__read_levels_from_device).result(timeout=self.__cmd_timeout)
 
-    def __read_levels_from_device(self) -> dict:
+    def __read_levels_from_device(self) -> Dict[str, Any]:
         lines = None
         try:
             kwargs = {'retcode': None} if self.__ignore_retcode else {}
@@ -798,7 +798,7 @@ class Minidsp(PersistentDevice[MinidspState]):
 
             sched()
 
-    def on_ws_message(self, msg: dict):
+    def on_ws_message(self, msg: Dict[str, Any]) -> None:
         logger.debug(f"[{self.name}] Received {msg}")
         if 'master' in msg:
             master = msg['master']
@@ -859,7 +859,7 @@ class MinidspBeqCommandGenerator:
         return cmds
 
     @staticmethod
-    def as_bq(f: dict, fs: str):
+    def as_bq(f: dict, fs: str) -> List[str]:
         if fs in f['biquads']:
             bq = f['biquads'][fs]['b'] + f['biquads'][fs]['a']
         else:
@@ -912,13 +912,13 @@ class MinidspBeqCommandGenerator:
         return cmds
 
     @staticmethod
-    def bq(channel: int, idx: int, coeffs, side: str = INPUT_NAME, group: int | None = None):
+    def bq(channel: int, idx: int, coeffs: List[str], side: str = INPUT_NAME, group: int | None = None):
         is_xo = side == CROSSOVER_NAME
         addr = f"crossover {group}" if is_xo and group is not None else 'peq'
         return f"{OUTPUT_NAME if is_xo else side} {channel} {addr} {idx} set -- {' '.join(coeffs)}"
 
     @staticmethod
-    def cmd(channel: int, cmd: str, side: str = INPUT_NAME):
+    def cmd(channel: int, cmd: str, side: str = INPUT_NAME) -> str:
         return f"{side} {channel} {cmd}"
 
     @staticmethod
@@ -995,7 +995,7 @@ def tmp_file(cmds: list[str]):
 
 class MinidspRsClient:
 
-    def __init__(self, listener, ip, device_id):
+    def __init__(self, listener: 'Minidsp', ip: str, device_id: Union[int, str]):
         ws_url = f"ws://{ip}/devices/{device_id}?levels=true&poll=true"
         logger.info(f"Listening to ws on {ws_url}")
         self.__factory = MinidspRsClientFactory(listener, device_id, url=ws_url)
@@ -1005,29 +1005,29 @@ class MinidspRsClient:
         wsclient = clientFromString(reactor, f"tcp:{ip}:timeout=5")
         self.__connector = wsclient.connect(self.__factory)
 
-    def send(self, msg: str):
+    def send(self, msg: str) -> None:
         self.__factory.broadcast(msg)
 
 
 class MinidspRsProtocol(WebSocketClientProtocol):
 
-    def onConnecting(self, transport_details):
+    def onConnecting(self, transport_details: Any) -> None:
         logger.info(f"Connecting to {transport_details}")
 
-    def onConnect(self, response):
+    def onConnect(self, response: Any) -> None:
         logger.info(f"Connected to {response.peer}")
 
-    def onOpen(self):
+    def onOpen(self) -> None:
         logger.info("Connected to Minidsp")
         self.factory.register(self)
 
-    def onClose(self, was_clean, code, reason):
+    def onClose(self, was_clean: bool, code: Optional[int], reason: Optional[str]) -> None:
         if was_clean:
             logger.info(f"Disconnected code: {code} reason: {reason}")
         else:
             logger.warning(f"UNCLEAN! Disconnected code: {code} reason: {reason}")
 
-    def onMessage(self, payload, is_binary):
+    def onMessage(self, payload: Union[bytes, str], is_binary: bool) -> None:
         if is_binary:
             logger.warning(f"Received {len(payload)} bytes in binary payload, ignoring")
         else:
@@ -1044,21 +1044,21 @@ class MinidspRsClientFactory(WebSocketClientFactory, ReconnectingClientFactory):
     maxDelay = 5
     initialDelay = 0.5
 
-    def __init__(self, listener, device_id, *args, **kwargs):
+    def __init__(self, listener: 'Minidsp', device_id: Union[int, str], *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self.__device_id = device_id
         self.__clients: list[MinidspRsProtocol] = []
         self.listener = listener
 
     @property
-    def device_id(self):
+    def device_id(self) -> Union[int, str]:
         return self.__device_id
 
-    def clientConnectionFailed(self, connector, reason):
+    def clientConnectionFailed(self, connector: Any, reason: Any) -> None:
         logger.warning(f"[{self.device_id}] Client connection failed {reason} .. retrying ..")
         super().clientConnectionFailed(connector, reason)
 
-    def clientConnectionLost(self, connector, reason):
+    def clientConnectionLost(self, connector: Any, reason: Any) -> None:
         logger.warning(f"[{self.device_id}] Client connection failed {reason} .. retrying ..")
         super().clientConnectionLost(connector, reason)
 
@@ -1076,7 +1076,7 @@ class MinidspRsClientFactory(WebSocketClientFactory, ReconnectingClientFactory):
         else:
             logger.info(f"Ignoring unregistered device {client.peer}")
 
-    def broadcast(self, msg):
+    def broadcast(self, msg: str) -> None:
         if self.__clients:
             disconnected_clients = []
             for c in self.__clients:
@@ -1092,7 +1092,7 @@ class MinidspRsClientFactory(WebSocketClientFactory, ReconnectingClientFactory):
             raise ValueError(f"No devices connected, ignoring {msg}")
 
 
-def format_levels(levels: dict) -> dict:
+def format_levels(levels: Dict[str, Any]) -> Dict[str, float]:
     # quick hack for testing purposes
     # INPUT_NAME: [x + ((random() * 5) * (-1.0 if self.name == 'd1' else 1.0)) for x in msg['input_levels']],
     return {

--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -134,8 +134,8 @@ class MinidspState(DeviceState):
         slot.last_author = author
         self.activate(slot_id)
 
-    def get_slot(self, slot_id: str) -> 'MinidspSlotState':
-        return next(s for s in self.__slots if s.slot_id == slot_id)
+    def get_slot(self, slot_id: str) -> Optional['MinidspSlotState']:
+        return next((s for s in self.__slots if s.slot_id == slot_id), None)
 
     def clear(self, slot_id: str) -> None:
         slot = self.get_slot(slot_id)
@@ -169,6 +169,14 @@ class MinidspState(DeviceState):
                 slot.unmute(channel)
             self.activate(slot_id)
 
+    def output_gain(self, slot_id: str, channel: int | None, gain: float):
+        self.get_slot(slot_id).set_output_gain(channel, gain)
+        self.activate(slot_id)
+
+    def toggle_output_mute(self, slot_id: str, channel: int | None, mute: bool):
+        self.get_slot(slot_id).set_output_mute(channel, mute)
+        self.activate(slot_id)
+
     def serialise(self) -> dict:
         serials = {'serials': self.__serials} if self.__serials else {}
         return {
@@ -196,6 +204,8 @@ class MinidspSlotState(SlotState['MinidspSlotState']):
         self.__output_channels = output_channels
         self.gains = self.__make_vals(0.0)
         self.mutes = self.__make_vals(False)
+        self.output_gains = self.__make_output_vals(0.0)
+        self.output_mutes = self.__make_output_vals(False)
         self.active = active
         self.slot_name = slot_name
 
@@ -203,9 +213,14 @@ class MinidspSlotState(SlotState['MinidspSlotState']):
         super().clear()
         self.gains = self.__make_vals(0.0)
         self.mutes = self.__make_vals(False)
+        self.output_gains = self.__make_output_vals(0.0)
+        self.output_mutes = self.__make_output_vals(False)
 
     def __make_vals(self, val: float | bool) -> list[dict]:
         return [{'id': str(i + 1), 'value': val} for i in range(self.__input_channels)]
+
+    def __make_output_vals(self, val: float | bool) -> list[dict]:
+        return [{'id': str(i + 1), 'value': val} for i in range(self.__output_channels)]
 
     def set_gain(self, channel: int | None, value: float):
         if channel is None:
@@ -215,6 +230,15 @@ class MinidspSlotState(SlotState['MinidspSlotState']):
                 next(g for g in self.gains if g['id'] == str(channel))['value'] = value
             else:
                 raise ValueError(f'Unknown channel {channel} for slot {self.slot_id}')
+
+    def set_output_gain(self, channel: int | None, value: float):
+        if channel is None:
+            self.output_gains = self.__make_output_vals(value)
+        else:
+            if channel <= self.__output_channels:
+                next(g for g in self.output_gains if g['id'] == str(channel))['value'] = value
+            else:
+                raise ValueError(f'Unknown output channel {channel} for slot {self.slot_id}')
 
     def mute(self, channel: int | None):
         self.__do_mute(channel, True)
@@ -227,6 +251,15 @@ class MinidspSlotState(SlotState['MinidspSlotState']):
                 next(g for g in self.mutes if g['id'] == str(channel))['value'] = value
             else:
                 raise ValueError(f'Unknown channel {channel} for slot {self.slot_id}')
+
+    def set_output_mute(self, channel: int | None, value: bool):
+        if channel is None:
+            self.output_mutes = self.__make_output_vals(value)
+        else:
+            if channel <= self.__output_channels:
+                next(g for g in self.output_mutes if g['id'] == str(channel))['value'] = value
+            else:
+                raise ValueError(f'Unknown output channel {channel} for slot {self.slot_id}')
 
     def unmute(self, channel: int | None):
         self.__do_mute(channel, False)
@@ -247,12 +280,26 @@ class MinidspSlotState(SlotState['MinidspSlotState']):
                     self.mutes.append(m)
                 else:
                     self.mutes.append({'id': str(i + 1), 'value': bool(m)})
+        if 'outputGains' in state and len(state['outputGains']) == self.__output_channels:
+            self.output_gains = []
+            for i, g in enumerate(state['outputGains']):
+                if isinstance(g, dict):
+                    self.output_gains.append(g)
+                else:
+                    self.output_gains.append({'id': str(i + 1), 'value': float(g)})
+        if 'outputMutes' in state and len(state['outputMutes']) == self.__output_channels:
+            self.output_mutes = []
+            for i, m in enumerate(state['outputMutes']):
+                if isinstance(m, dict):
+                    self.output_mutes.append(m)
+                else:
+                    self.output_mutes.append({'id': str(i + 1), 'value': bool(m)})
 
     def as_dict(self) -> dict:
         sup = super().as_dict()
         if self.slot_name:
             sup['name'] = self.slot_name
-        return {
+        result = {
             **sup,
             'gains': self.gains,
             'mutes': self.mutes,
@@ -260,6 +307,10 @@ class MinidspSlotState(SlotState['MinidspSlotState']):
             'inputs': self.__input_channels,
             'outputs': self.__output_channels,
         }
+        if self.__output_channels > 0:
+            result['outputGains'] = self.output_gains
+            result['outputMutes'] = self.output_mutes
+        return result
 
     def __repr__(self) -> str:
         vals = ' '.join([f"{g['id']}: {g['value']:.2f}/{self.mutes[i]['value']}" for i, g in enumerate(self.gains)])
@@ -737,6 +788,31 @@ class Minidsp(PersistentDevice[MinidspState]):
 
         self._hydrate_cache_broadcast(__do_it)
 
+    def set_output_gain(self, slot: str, channel: Optional[int], gain: float) -> None:
+        def __do_it():
+            target_channel_idx, target_slot_idx = self.__as_idxes(channel, slot)
+            cmds = MinidspBeqCommandGenerator.gain(gain, target_slot_idx, target_channel_idx, side=OUTPUT_NAME)
+            self.__send_cmds(target_slot_idx, cmds)
+            self._current_state.output_gain(slot, channel, gain)
+
+        self._hydrate_cache_broadcast(__do_it)
+
+    def __do_output_mute_op(self, slot: str, channel: Optional[int], state: bool) -> None:
+        def __do_it():
+            target_channel_idx, target_slot_idx = self.__as_idxes(channel, slot)
+            self.__validate_slot_idx(target_slot_idx)
+            cmds = MinidspBeqCommandGenerator.mute(state, target_slot_idx, target_channel_idx, side=OUTPUT_NAME)
+            self.__send_cmds(target_slot_idx, cmds)
+            self._current_state.toggle_output_mute(slot, channel, state)
+
+        self._hydrate_cache_broadcast(__do_it)
+
+    def output_mute(self, slot: str, channel: Optional[int]) -> None:
+        self.__do_output_mute_op(slot, channel, True)
+
+    def output_unmute(self, slot: str, channel: Optional[int]) -> None:
+        self.__do_output_mute_op(slot, channel, False)
+
     def __as_idxes(self, channel: Optional[int], slot: Optional[str]) -> Tuple[Optional[int], Optional[int]]:
         target_slot_idx = self.__as_idx(slot) if slot else None
         target_channel_idx = self.__as_idx(channel) if channel else None
@@ -831,6 +907,17 @@ class Minidsp(PersistentDevice[MinidspState]):
                     self.mute(current_slot.slot_id, int(mute['id']))
                 else:
                     self.unmute(current_slot.slot_id, int(mute['id']))
+                any_update = True
+        if 'outputGains' in slot:
+            for gain in slot['outputGains']:
+                self.set_output_gain(current_slot.slot_id, int(gain['id']), gain['value'])
+                any_update = True
+        if 'outputMutes' in slot:
+            for mute in slot['outputMutes']:
+                if mute['value'] is True:
+                    self.output_mute(current_slot.slot_id, int(mute['id']))
+                else:
+                    self.output_unmute(current_slot.slot_id, int(mute['id']))
                 any_update = True
         if 'entry' in slot:
             if slot['entry']:

--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -2,9 +2,11 @@ import json
 import logging
 import math
 import os
+import re
 import time
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import contextmanager
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import yaml
 from autobahn.exception import Disconnected
@@ -22,6 +24,71 @@ OUTPUT_NAME = 'output'
 CROSSOVER_NAME = 'crossover'
 
 logger = logging.getLogger('ezbeq.minidsp')
+
+_CONFIG_PATTERN = re.compile(r'config ([0-3])')
+_GAIN_PATTERN = re.compile(r'gain -- ([-+]?\d*\.\d+|\d+)')
+
+
+class MinidspStubRunner:
+    """
+    Simulates the minidsp CLI for local development without hardware.
+    Configure via: exe: stub in ezbeq.yml
+    """
+
+    def __init__(self):
+        self.__slot = 0
+        self.__gain = 0.0
+        self.__mute = False
+        self.__pending = None
+
+    def __getitem__(self, item):
+        self.__pending = item
+        return self
+
+    def __make_status(self) -> str:
+        return json.dumps({
+            'master': {
+                'preset': self.__slot,
+                'source': 'Usb',
+                'volume': self.__gain,
+                'mute': self.__mute
+            },
+            'input_levels': [0.0, 0.0],
+            'output_levels': [0.0, 0.0, 0.0, 0.0]
+        })
+
+    def __apply_file(self, filepath: str):
+        with open(filepath) as f:
+            cmds = [c for c in f.read().split('\n') if c]
+        for cmd in cmds:
+            if cmd == 'mute on':
+                self.__mute = True
+            elif cmd == 'mute off':
+                self.__mute = False
+            else:
+                m = _GAIN_PATTERN.match(cmd)
+                if m:
+                    self.__gain = float(m.group(1))
+                else:
+                    m = _CONFIG_PATTERN.match(cmd)
+                    if m:
+                        self.__slot = int(m.group(1))
+
+    def __call__(self, *args, **kwargs):
+        pending, self.__pending = self.__pending, None
+        if isinstance(pending, tuple) and len(pending) == 2 and pending[0] == '-f':
+            self.__apply_file(pending[1])
+        return self.__make_status()
+
+    def run(self, *args, **kwargs):
+        pending, self.__pending = self.__pending, None
+        if isinstance(pending, tuple) and len(pending) == 2 and pending[0] == '-f':
+            self.__apply_file(pending[1])
+            return 0, '', ''
+        return 0, self.__make_status(), ''
+
+    def __repr__(self) -> str:
+        return 'MinidspStubRunner'
 
 
 class MinidspState(DeviceState):
@@ -262,7 +329,7 @@ class BeqFilterAllocator:
 class MinidspDescriptor:
 
     def __init__(self, name: str, fs: str, i: PeqRoutes | None = None, xo: PeqRoutes | None = None,
-                 o: PeqRoutes | None = None, extra: list[PeqRoutes] = None, slot_names: Optional[Dict[str, str]] = None):
+                 o: PeqRoutes | None = None, extra: Optional[List[PeqRoutes]] = None, slot_names: Optional[Dict[str, str]] = None):
         self.name = name
         self.fs = str(int(fs))
         self.input = i
@@ -330,7 +397,7 @@ class MinidspDDRC24(MinidspDescriptor):
 
 class MinidspHTX(MinidspDescriptor):
 
-    def __init__(self, slot_names: Optional[Dict[str, str]] = None, channels: list[int] = None, use_inputs: bool = False):
+    def __init__(self, slot_names: Optional[Dict[str, str]] = None, channels: Optional[List[int]] = None, use_inputs: bool = False):
         c = channels if channels is not None else [3]
         if any(ch for ch in c if ch < 0 or ch > 7):
             raise ValueError(f"Invalid channels {c} must be between 0 and 7")
@@ -489,7 +556,7 @@ class Minidsp(PersistentDevice[MinidspState]):
             self.__ws_client = None
         self.__descriptor: MinidspDescriptor = make_peq_layout(cfg, self.__runner)
         logger.info(f"[{name}] Minidsp descriptor is loaded.... exe is {self.__runner}")
-        logger.info(yaml.dump(self.__descriptor, indent=2, default_flow_style=False, sort_keys=False))
+        logger.debug(yaml.dump(self.__descriptor, indent=2, default_flow_style=False, sort_keys=False))
         ws_server.factory.set_levels_provider(name, self.start_broadcast_levels)
 
     @property
@@ -601,6 +668,7 @@ class Minidsp(PersistentDevice[MinidspState]):
             target_slot_idx = self.__as_idx(slot)
             self.__validate_slot_idx(target_slot_idx)
             cmds = MinidspBeqCommandGenerator.filt(entry, self.__descriptor)
+            logger.info(f"[{self.name}] Loading '{entry.formatted_title}' to slot {slot} ({len(cmds)} commands)")
             try:
                 self.__send_cmds(target_slot_idx, cmds)
                 self._current_state.load(slot, entry.formatted_title, entry.author)
@@ -686,7 +754,7 @@ class Minidsp(PersistentDevice[MinidspState]):
                         f"[{self.name}] Activating slot {slot}, current is {current_state.active_slot if current_state else 'UNKNOWN'}")
                     config_cmds.insert(0, MinidspBeqCommandGenerator.activate(slot))
         formatted = '\n'.join(config_cmds)
-        logger.info(f"\n{formatted}")
+        logger.debug(f"\n{formatted}")
         with tmp_file(config_cmds) as file_name:
             kwargs = {'retcode': None} if self.__ignore_retcode else {}
             exe = self.__runner['-f', file_name]
@@ -777,7 +845,7 @@ class Minidsp(PersistentDevice[MinidspState]):
             end = time.time()
             levels = json.loads(lines)
             ts = time.time()
-            logger.info(f"{self.name},readlevels,{ts},{to_millis(start, end)}")
+            logger.debug(f"{self.name},readlevels,{ts},{to_millis(start, end)}")
             return {
                 'name': self.name,
                 'ts': ts,
@@ -1012,10 +1080,10 @@ class MinidspRsClient:
 class MinidspRsProtocol(WebSocketClientProtocol):
 
     def onConnecting(self, transport_details: Any) -> None:
-        logger.info(f"Connecting to {transport_details}")
+        logger.debug(f"Connecting to {transport_details}")
 
     def onConnect(self, response: Any) -> None:
-        logger.info(f"Connected to {response.peer}")
+        logger.debug(f"Connected to {response.peer}")
 
     def onOpen(self) -> None:
         logger.info("Connected to Minidsp")
@@ -1064,23 +1132,23 @@ class MinidspRsClientFactory(WebSocketClientFactory, ReconnectingClientFactory):
 
     def register(self, client: MinidspRsProtocol):
         if client not in self.__clients:
-            logger.info(f"[{self.device_id}] Registered device {client.peer}")
+            logger.debug(f"[{self.device_id}] Registered device {client.peer}")
             self.__clients.append(client)
         else:
-            logger.info(f"[{self.device_id}] Ignoring duplicate device {client.peer}")
+            logger.debug(f"[{self.device_id}] Ignoring duplicate device {client.peer}")
 
     def unregister(self, client: MinidspRsProtocol):
         if client in self.__clients:
-            logger.info(f"Unregistering device {client.peer}")
+            logger.debug(f"Unregistering device {client.peer}")
             self.__clients.remove(client)
         else:
-            logger.info(f"Ignoring unregistered device {client.peer}")
+            logger.debug(f"Ignoring unregistered device {client.peer}")
 
     def broadcast(self, msg: str) -> None:
         if self.__clients:
             disconnected_clients = []
             for c in self.__clients:
-                logger.info(f"[{self.device_id}] Sending to {c.peer} - {msg}")
+                logger.debug(f"[{self.device_id}] Sending to {c.peer} - {msg}")
                 try:
                     c.sendMessage(msg.encode('utf8'))
                 except Disconnected:

--- a/ezbeq/minidsp.py
+++ b/ezbeq/minidsp.py
@@ -99,6 +99,7 @@ class MinidspState(DeviceState):
         self.__mute: bool = kwargs['mute'] if 'mute' in kwargs else False
         self.__active_slot: str = kwargs['active_slot'] if 'active_slot' in kwargs else ''
         self.__serials: list = kwargs['serials'] if 'serials' in kwargs else []
+        self.connected: bool = kwargs.get('connected', True)
         self.__descriptor = descriptor
         slot_ids = [str(i + 1) for i in range(4)]
         self.__slots: list[MinidspSlotState] = [
@@ -175,6 +176,7 @@ class MinidspState(DeviceState):
             'name': self.__name,
             'masterVolume': self.master_volume,
             'mute': self.__mute,
+            'connected': self.connected,
             'slots': [s.as_dict() for s in self.__slots],
         } | serials
 
@@ -565,7 +567,7 @@ class Minidsp(PersistentDevice[MinidspState]):
 
     def __load_state(self) -> MinidspState:
         result = self.__executor.submit(self.__read_state_from_device).result(timeout=self.__cmd_timeout)
-        return result if result else MinidspState(self.name, self.__descriptor)
+        return result if result else MinidspState(self.name, self.__descriptor, connected=False)
 
     def __read_state_from_device(self) -> MinidspState | None:
         output = None
@@ -601,9 +603,13 @@ class Minidsp(PersistentDevice[MinidspState]):
                     logger.warning(f'[{self.name}] Unable to probe')
                 return MinidspState(self.name, self.__descriptor, **values)
             else:
-                logger.error(f"[{self.name}] No output returned from device")
+                msg = f"[{self.name}] No output returned from device"
+                logger.error(msg)
+                self.ws_server.broadcast_error(msg, persistent=True)
         except Exception as e:
-            logger.exception(f"[{self.name}] Unable to parse device state {output}")
+            msg = f"[{self.name}] Unable to parse device state {output}"
+            logger.exception(msg)
+            self.ws_server.broadcast_error(msg, persistent=True)
         return None
 
     @staticmethod
@@ -775,7 +781,11 @@ class Minidsp(PersistentDevice[MinidspState]):
     def state(self, refresh: bool = False) -> MinidspState:
         if not self._hydrate() or refresh is True:
             new_state = self.__load_state()
+            old_connected = self._current_state.connected
             self._current_state.update_master_state(new_state.mute, new_state.master_volume)
+            self._current_state.connected = new_state.connected
+            if old_connected != self._current_state.connected:
+                self._broadcast()
         return self._current_state
 
     def _merge_state(self, loaded: MinidspState, cached: dict) -> MinidspState:

--- a/ezbeq/qsys.py
+++ b/ezbeq/qsys.py
@@ -173,7 +173,7 @@ class Qsys(PersistentDevice[QsysState]):
             try:
                 result = json.loads(msg)
                 logger.info(f"Received from {name}: {result}")
-            except:
+            except json.JSONDecodeError as e:
                 logger.exception(f"Unable to decode {msg}")
         else:
             logger.info(f"Received no data from {name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,11 @@ optional = true
 [tool.poetry.group.exe.dependencies]
 pyinstaller = { version = "^6.9.0", python = ">=3.13,<3.15" }
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: starts a real Twisted server subprocess (slower)",
+]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,6 +199,19 @@ def multi_camilladsp3_client(multi_camilladsp3_app):
     return multi_camilladsp3_app.test_client()
 
 
+@pytest.fixture
+def stub_app(tmp_path):
+    """App instance using MinidspStubRunner - no hardware required."""
+    app, ws = main.create_app(StubConfig(tmp_path))
+    yield app
+
+
+@pytest.fixture
+def stub_client(stub_app):
+    """Test client for the stub app."""
+    return stub_app.test_client()
+
+
 CONFIG_PATTERN = re.compile(r'config ([0-3])')
 GAIN_PATTERN = re.compile(r'gain -- ([-+]?\d*\.\d+|\d+)')
 
@@ -462,6 +475,41 @@ class CapturingWsServerFactory(WsServerFactory):
 
     def set_levels_provider(self, name: str, broadcaster: Callable[[], None]):
         pass
+
+
+class StubConfig(Config):
+    """Config that uses MinidspStubRunner - no hardware or minidsp binary required."""
+
+    def __init__(self, tmp_path):
+        self.__tmp_path = tmp_path
+        super().__init__('stub')
+
+    def load_config(self):
+        return {
+            'debugLogging': False,
+            'accessLogging': False,
+            'port': 8080,
+            'devices': {
+                'master': {
+                    'type': 'minidsp',
+                    'exe': 'stub',
+                    'cmdTimeout': 10,
+                    'make_runner': self.create_minidsp_runner
+                }
+            }
+        }
+
+    @property
+    def config_path(self):
+        return str(self.__tmp_path)
+
+    @property
+    def version(self):
+        return '1.2.3'
+
+    @property
+    def load_catalogue_at_startup(self):
+        return False
 
 
 class CapturingWsServer(WsServer[CapturingWsServerFactory]):

--- a/tests/test_minidsp_api.py
+++ b/tests/test_minidsp_api.py
@@ -2059,6 +2059,115 @@ def test_patch_v3_multiple_fields(minidsp_client, minidsp_app):
             verify_slot(s, idx + 1)
 
 
+@pytest.mark.parametrize("slot", [1, 2, 3, 4])
+@pytest.mark.parametrize("mute_value", [True, False])
+def test_patch_v3_output_mute_all_channels(minidsp_client, minidsp_app, slot, mute_value):
+    """PATCH v3 with outputMutes for every output channel issues one `output N mute on/off` per channel."""
+    config: MinidspSpyConfig = minidsp_app.config['APP_CONFIG']
+    assert isinstance(config, MinidspSpyConfig)
+    payload = {
+        'slots': [{
+            'id': str(slot),
+            'outputMutes': [{'id': str(i), 'value': mute_value} for i in range(1, 5)]
+        }]
+    }
+    r = minidsp_client.patch(f"/api/3/devices/master", data=json.dumps(payload), content_type='application/json')
+    assert r.status_code == 200
+    cmds = verify_cmd_count(config.spy, slot, 4)
+    op = 'on' if mute_value else 'off'
+    for i in range(4):
+        assert cmds[i] == f"output {i} mute {op}"
+    # state includes outputMutes for the target slot
+    slot_state = next(s for s in r.json['slots'] if s['id'] == str(slot))
+    assert len(slot_state['outputMutes']) == 4
+    for m in slot_state['outputMutes']:
+        assert m['value'] is mute_value
+
+
+@pytest.mark.parametrize("slot", [1, 2, 3, 4])
+@pytest.mark.parametrize("channel", [1, 2, 3, 4])
+@pytest.mark.parametrize("mute_value", [True, False])
+def test_patch_v3_output_mute_single_channel(minidsp_client, minidsp_app, slot, channel, mute_value):
+    """PATCH v3 with outputMutes for one channel only issues that single minidsp command."""
+    config: MinidspSpyConfig = minidsp_app.config['APP_CONFIG']
+    payload = {
+        'slots': [{
+            'id': str(slot),
+            'outputMutes': [{'id': str(channel), 'value': mute_value}]
+        }]
+    }
+    r = minidsp_client.patch(f"/api/3/devices/master", data=json.dumps(payload), content_type='application/json')
+    assert r.status_code == 200
+    cmds = verify_cmd_count(config.spy, slot, 1)
+    op = 'on' if mute_value else 'off'
+    assert cmds[0] == f"output {channel - 1} mute {op}"
+    # state has mute set only on the target channel, others remain default (False)
+    slot_state = next(s for s in r.json['slots'] if s['id'] == str(slot))
+    assert len(slot_state['outputMutes']) == 4
+    for m in slot_state['outputMutes']:
+        if m['id'] == str(channel):
+            assert m['value'] is mute_value
+        else:
+            assert m['value'] is False
+
+
+@pytest.mark.parametrize("slot", [1, 2, 3, 4])
+@pytest.mark.parametrize("gain", [-12.5, 0.0, 6.25])
+def test_patch_v3_output_gain_all_channels(minidsp_client, minidsp_app, slot, gain):
+    """PATCH v3 with outputGains sets gain on every output channel."""
+    config: MinidspSpyConfig = minidsp_app.config['APP_CONFIG']
+    payload = {
+        'slots': [{
+            'id': str(slot),
+            'outputGains': [{'id': str(i), 'value': gain} for i in range(1, 5)]
+        }]
+    }
+    r = minidsp_client.patch(f"/api/3/devices/master", data=json.dumps(payload), content_type='application/json')
+    assert r.status_code == 200
+    cmds = verify_cmd_count(config.spy, slot, 4)
+    for i in range(4):
+        assert cmds[i] == f"output {i} gain -- {gain:.2f}"
+    slot_state = next(s for s in r.json['slots'] if s['id'] == str(slot))
+    assert len(slot_state['outputGains']) == 4
+    for g in slot_state['outputGains']:
+        assert g['value'] == gain
+
+
+@pytest.mark.parametrize("channel", [1, 2, 3, 4])
+def test_patch_v3_output_gain_single_channel(minidsp_client, minidsp_app, channel):
+    """PATCH v3 with one outputGain only touches that channel; others remain 0.0."""
+    config: MinidspSpyConfig = minidsp_app.config['APP_CONFIG']
+    payload = {
+        'slots': [{
+            'id': '1',
+            'outputGains': [{'id': str(channel), 'value': -3.5}]
+        }]
+    }
+    r = minidsp_client.patch(f"/api/3/devices/master", data=json.dumps(payload), content_type='application/json')
+    assert r.status_code == 200
+    cmds = verify_cmd_count(config.spy, 1, 1)
+    assert cmds[0] == f"output {channel - 1} gain -- -3.50"
+    slot_state = next(s for s in r.json['slots'] if s['id'] == '1')
+    for g in slot_state['outputGains']:
+        if g['id'] == str(channel):
+            assert g['value'] == -3.5
+        else:
+            assert g['value'] == 0.0
+
+
+def test_default_state_includes_output_gains_and_mutes(minidsp_client, minidsp_app):
+    """2x4HD has 4 outputs so every slot exposes outputGains/outputMutes in the default state."""
+    r = minidsp_client.get("/api/1/devices")
+    assert r.status_code == 200
+    for slot in r.json['slots']:
+        assert len(slot['outputGains']) == 4
+        assert len(slot['outputMutes']) == 4
+        for g in slot['outputGains']:
+            assert g['value'] == 0.0
+        for m in slot['outputMutes']:
+            assert m['value'] is False
+
+
 def test_patch_v2_multiple_fields(minidsp_client, minidsp_app):
     config: MinidspSpyConfig = minidsp_app.config['APP_CONFIG']
     assert isinstance(config, MinidspSpyConfig)

--- a/tests/test_stub.py
+++ b/tests/test_stub.py
@@ -1,0 +1,114 @@
+"""
+Smoke tests for the stub device mode.
+
+Fast tests use the Flask test client (no Twisted, no subprocess).
+Integration tests (marked 'integration') start the real Twisted server
+as a subprocess and make actual HTTP requests to it.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+import requests
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Fast API smoke tests (Flask test client)
+# ---------------------------------------------------------------------------
+
+def test_stub_device_initial_state(stub_client):
+    r = stub_client.get('/api/1/devices')
+    assert r.status_code == 200
+    devices = r.json
+    assert devices['name'] == 'master'
+    assert devices['mute'] is False
+    assert float(devices['masterVolume']) == 0.0
+    slots = devices['slots']
+    assert len(slots) == 4
+    assert slots[0]['active'] is True
+    assert all(s['last'] == 'Empty' for s in slots)
+
+
+def test_stub_mute_unmute(stub_client):
+    r = stub_client.put('/api/1/devices/master/mute')
+    assert r.status_code == 200
+    assert r.json['mute'] is True
+
+    r = stub_client.delete('/api/1/devices/master/mute')
+    assert r.status_code == 200
+    assert r.json['mute'] is False
+
+
+def test_stub_activate_slot(stub_client):
+    r = stub_client.put('/api/1/devices/master/config/2/active')
+    assert r.status_code == 200
+    slots = r.json['slots']
+    assert slots[1]['active'] is True
+    assert slots[0]['active'] is False
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke test (real Twisted server, subprocess)
+# ---------------------------------------------------------------------------
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope='module')
+def live_stub_server(tmp_path_factory):
+    port = _free_port()
+    config_dir = tmp_path_factory.mktemp('live_stub')
+    config = {
+        'port': port,
+        'accessLogging': False,
+        'debugLogging': False,
+        'devices': {'master': {'type': 'minidsp', 'exe': 'stub', 'cmdTimeout': 10}}
+    }
+    (config_dir / 'ezbeq.yml').write_text(yaml.dump(config))
+
+    env = {**os.environ, 'EZBEQ_CONFIG_HOME': str(config_dir)}
+    proc = subprocess.Popen(
+        [sys.executable, '-m', 'ezbeq.main'],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    base_url = f'http://127.0.0.1:{port}'
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        try:
+            requests.get(f'{base_url}/api/1/devices', timeout=1)
+            break
+        except requests.ConnectionError:
+            time.sleep(0.2)
+    else:
+        proc.terminate()
+        pytest.fail('Stub server did not become ready within 15 seconds')
+
+    yield base_url
+
+    proc.terminate()
+    proc.wait(timeout=5)
+
+
+@pytest.mark.integration
+def test_live_stub_api(live_stub_server):
+    r = requests.get(f'{live_stub_server}/api/1/devices')
+    assert r.status_code == 200
+    assert r.json()['name'] == 'master'
+
+
+@pytest.mark.integration
+def test_live_stub_root_no_error(live_stub_server):
+    """Root path should return a clean 404, not Twisted's 'Processing Failed' error page."""
+    r = requests.get(f'{live_stub_server}/')
+    assert 'Processing Failed' not in r.text

--- a/tests/test_version_api.py
+++ b/tests/test_version_api.py
@@ -1,0 +1,108 @@
+import os
+
+import pytest
+
+from conftest import MinidspSpyConfig
+
+
+_UNSET = object()
+
+
+class VersionedConfig(MinidspSpyConfig):
+    """MinidspSpyConfig with controllable version and git_info."""
+
+    def __init__(self, host, port, tmp_path, version='1.2.3', git_info=_UNSET):
+        self.__version = version
+        self.__git_info = git_info
+        super().__init__(host, port, tmp_path)
+
+    @property
+    def version(self):
+        return self.__version
+
+    @property
+    def git_info(self):
+        if self.__git_info is _UNSET:
+            return super().git_info
+        return self.__git_info
+
+
+@pytest.fixture
+def version_client_no_git(httpserver, tmp_path):
+    from ezbeq import main
+    app, _ = main.create_app(VersionedConfig(httpserver.host, httpserver.port, tmp_path,
+                                              version='1.2.3',
+                                              git_info={'branch': None, 'sha': None}))
+    return app.test_client()
+
+
+@pytest.fixture
+def version_client_with_git(httpserver, tmp_path):
+    from ezbeq import main
+    app, _ = main.create_app(VersionedConfig(httpserver.host, httpserver.port, tmp_path,
+                                              version='1.2.3',
+                                              git_info={'branch': 'feats/my-feature', 'sha': 'abc1234'}))
+    return app.test_client()
+
+
+@pytest.fixture
+def version_client_unknown(httpserver, tmp_path):
+    from ezbeq import main
+    app, _ = main.create_app(VersionedConfig(httpserver.host, httpserver.port, tmp_path,
+                                              version='UNKNOWN',
+                                              git_info={'branch': 'main', 'sha': 'deadbee'}))
+    return app.test_client()
+
+
+def test_version_returns_version(version_client_no_git):
+    r = version_client_no_git.get('/api/1/version')
+    assert r.status_code == 200
+    assert r.json['version'] == '1.2.3'
+
+
+def test_version_no_git_info_omits_branch_and_sha(version_client_no_git):
+    r = version_client_no_git.get('/api/1/version')
+    assert r.status_code == 200
+    assert 'branch' not in r.json
+    assert 'sha' not in r.json
+
+
+def test_version_with_git_info_includes_branch_and_sha(version_client_with_git):
+    r = version_client_with_git.get('/api/1/version')
+    assert r.status_code == 200
+    assert r.json['version'] == '1.2.3'
+    assert r.json['branch'] == 'feats/my-feature'
+    assert r.json['sha'] == 'abc1234'
+
+
+def test_version_unknown_with_git_still_returns_git_info(version_client_unknown):
+    r = version_client_unknown.get('/api/1/version')
+    assert r.status_code == 200
+    assert r.json['version'] == 'UNKNOWN'
+    assert r.json['branch'] == 'main'
+    assert r.json['sha'] == 'deadbee'
+
+
+def test_version_env_vars_take_priority(httpserver, tmp_path, monkeypatch):
+    """GIT_BRANCH/GIT_SHA env vars (set by Docker) are used when present."""
+    monkeypatch.setenv('GIT_BRANCH', 'feats/docker-branch')
+    monkeypatch.setenv('GIT_SHA', 'cafebabe')
+    from ezbeq import main
+    from ezbeq.config import Config
+    cfg = Config.__new__(Config)
+    info = cfg.git_info
+    assert info['branch'] == 'feats/docker-branch'
+    assert info['sha'] == 'cafebabe'
+
+
+def test_version_env_vars_surfaced_in_api(httpserver, tmp_path, monkeypatch):
+    """GIT_BRANCH/GIT_SHA env vars appear in /api/1/version response."""
+    monkeypatch.setenv('GIT_BRANCH', 'feats/docker-branch')
+    monkeypatch.setenv('GIT_SHA', 'cafebabe')
+    from ezbeq import main
+    app, _ = main.create_app(VersionedConfig(httpserver.host, httpserver.port, tmp_path,
+                                              version='1.2.3'))
+    r = app.test_client().get('/api/1/version')
+    assert r.status_code == 200
+    assert r.json['branch'] == 'feats/docker-branch'
+    assert r.json['sha'] == 'cafebabe'

--- a/tests/test_whats_new_api.py
+++ b/tests/test_whats_new_api.py
@@ -1,0 +1,42 @@
+import time
+
+
+def test_returns_entry_when_since_predates_it(minidsp_client, minidsp_app):
+    r = minidsp_client.get('/api/1/whats-new', query_string={'since': 0})
+    assert r.status_code == 200
+    entries = r.json
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry['id'] == '123456_0'
+    assert entry['formattedTitle'] == 'Alien Resurrection'
+    assert entry['year'] == 1997
+    assert entry['author'] == 'aron7awol'
+    assert entry['content_type'] == 'film'
+    assert entry['created_at'] == 1611984156
+    assert entry['updated_at'] == 1543898641
+
+
+def test_returns_empty_when_since_is_in_the_future(minidsp_client, minidsp_app):
+    future = int(time.time()) + 60
+    r = minidsp_client.get('/api/1/whats-new', query_string={'since': future})
+    assert r.status_code == 200
+    assert r.json == []
+
+
+def test_default_since_is_two_weeks_excludes_old_entries(minidsp_client, minidsp_app):
+    # The fixture entry has created_at=1611984156 (2021), so default 2-week window returns nothing.
+    r = minidsp_client.get('/api/1/whats-new')
+    assert r.status_code == 200
+    assert r.json == []
+
+
+def test_limit_parameter_is_respected(minidsp_client, minidsp_app):
+    # Only one entry exists in the test catalogue; limit=1 should return it.
+    r = minidsp_client.get('/api/1/whats-new', query_string={'since': 0, 'limit': 1})
+    assert r.status_code == 200
+    assert len(r.json) == 1
+
+
+def test_ignores_invalid_since_value(minidsp_client, minidsp_app):
+    r = minidsp_client.get('/api/1/whats-new', query_string={'since': 'not-a-number'})
+    assert r.status_code == 400

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,6 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import CssBaseline from '@mui/material/CssBaseline';
 import {pushData} from "./services/util";
 import ErrorSnack from "./components/ErrorSnack";
+import SuccessSnack from "./components/SuccessSnack";
 import DeviceDisconnectedBanner from "./components/DeviceDisconnectedBanner";
 import MainView from "./components/main";
 import Levels from "./components/levels";
@@ -55,8 +56,9 @@ const App = () => {
         [prefersDarkMode],
     );
 
-    // errors
+    // errors and success
     const [err, setErr] = useState(null);
+    const [successMsg, setSuccessMsg] = useState(null);
 
     // catalogue data
     const [entries, setEntries] = useState({});
@@ -129,6 +131,7 @@ const App = () => {
                 <CssBaseline/>
                 <Root>
                     <ErrorSnack err={err} setErr={setErr}/>
+                    <SuccessSnack msg={successMsg} setMsg={setSuccessMsg}/>
                     {
                         selectedDeviceName && availableDevices[selectedDeviceName]?.connected === false
                             ? <DeviceDisconnectedBanner deviceName={selectedDeviceName}/>
@@ -139,6 +142,7 @@ const App = () => {
                             ?
                             <MainView entries={Object.keys(entries).map(e => entries[e])}
                                       setErr={setErr}
+                                      setSuccess={setSuccessMsg}
                                       replaceDevice={d => {
                                           if (ss && ss.isConnected()) {
                                               console.debug(`Discarding update, ws is connected`);

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,6 +6,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import CssBaseline from '@mui/material/CssBaseline';
 import {pushData} from "./services/util";
 import ErrorSnack from "./components/ErrorSnack";
+import DeviceDisconnectedBanner from "./components/DeviceDisconnectedBanner";
 import MainView from "./components/main";
 import Levels from "./components/levels";
 import Minidsp from "./components/minidsp";
@@ -128,6 +129,11 @@ const App = () => {
                 <CssBaseline/>
                 <Root>
                     <ErrorSnack err={err} setErr={setErr}/>
+                    {
+                        selectedDeviceName && availableDevices[selectedDeviceName]?.connected === false
+                            ? <DeviceDisconnectedBanner deviceName={selectedDeviceName}/>
+                            : null
+                    }
                     {
                         selectedNav === 'catalogue'
                             ?

--- a/ui/src/components/DeviceDisconnectedBanner.jsx
+++ b/ui/src/components/DeviceDisconnectedBanner.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+
+const DeviceDisconnectedBanner = ({deviceName}) => {
+    return (
+        <Alert
+            severity="error"
+            variant="filled"
+            sx={{borderRadius: 0, width: '100%'}}
+        >
+            <AlertTitle>Device Unreachable</AlertTitle>
+            {deviceName} is not responding — check connection and review ezbeq.log
+        </Alert>
+    );
+};
+
+export default DeviceDisconnectedBanner;

--- a/ui/src/components/ErrorSnack.jsx
+++ b/ui/src/components/ErrorSnack.jsx
@@ -1,38 +1,50 @@
 import React, {useEffect, useState} from 'react';
 import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 
 const ErrorSnack = ({err, setErr}) => {
     const [errTxt, setErrTxt] = useState(null);
+    const [persistent, setPersistent] = useState(false);
 
     useEffect(() => {
         if (err) {
             console.error(err);
             setErrTxt(err.message);
+            setPersistent(!!err.persistent);
         } else {
             setErrTxt(null);
+            setPersistent(false);
         }
     }, [err, setErrTxt]);
 
     const handleClose = (event, reason) => {
+        if (persistent && reason === 'clickaway') {
+            return;
+        }
         setErr(null);
     };
 
     return (
         <Snackbar
             open={errTxt !== null}
-            autoHideDuration={10000}
+            autoHideDuration={persistent ? null : 10000}
             onClose={handleClose}
-            message={err ? err.message : null}
-            action={
-                <>
+            anchorOrigin={persistent ? {vertical: 'top', horizontal: 'center'} : {vertical: 'bottom', horizontal: 'left'}}
+        >
+            <Alert
+                severity="error"
+                variant={persistent ? 'filled' : 'standard'}
+                action={
                     <IconButton size="small" aria-label="close" color="inherit" onClick={handleClose}>
                         <CloseIcon fontSize="small"/>
                     </IconButton>
-                </>
-            }
-        />
+                }
+            >
+                {errTxt}
+            </Alert>
+        </Snackbar>
     );
 }
 

--- a/ui/src/components/Header.jsx
+++ b/ui/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
-import {Avatar, Divider, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip} from "@mui/material";
+import {Avatar, Badge, Divider, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip} from "@mui/material";
 import beqcIcon from "../beqc.png";
 import React from "react";
 import Box from "@mui/material/Box";
@@ -9,6 +9,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import LocalLibraryIcon from "@mui/icons-material/LocalLibrary";
 import EqualizerIcon from "@mui/icons-material/Equalizer";
 import SettingsApplicationsIcon from "@mui/icons-material/SettingsApplications";
+import NewReleasesIcon from "@mui/icons-material/NewReleases";
 import {Check} from "@mui/icons-material";
 
 const Header = ({
@@ -17,6 +18,8 @@ const Header = ({
                     selectedDeviceName,
                     selectedNav,
                     setSelectedNav,
+                    whatsNewCount,
+                    onWhatsNewOpen,
                     children
                 }) => {
     const mobileMenuId = 'mobile-menu';
@@ -142,6 +145,11 @@ const Header = ({
                             variant="rounded"
                             src={beqcIcon}
                             sx={{width: 32, height: 32, marginLeft: '12px'}}/>
+                    <IconButton size="small" onClick={onWhatsNewOpen} aria-label="What's New" sx={{ml: 1}}>
+                        <Badge badgeContent={whatsNewCount || 0} color="error" max={99}>
+                            <NewReleasesIcon/>
+                        </Badge>
+                    </IconButton>
                     <Box sx={{flexGrow: 0.5}}/>
                     {children}
                     <Box sx={{flexGrow: 0.5, flexShrink: 2}}/>

--- a/ui/src/components/SuccessSnack.jsx
+++ b/ui/src/components/SuccessSnack.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+const SuccessSnack = ({msg, setMsg}) => {
+    return (
+        <Snackbar
+            open={msg !== null}
+            autoHideDuration={3000}
+            onClose={() => setMsg(null)}
+            anchorOrigin={{vertical: 'bottom', horizontal: 'left'}}
+        >
+            <Alert severity="success" variant="standard" onClose={() => setMsg(null)}>
+                {msg}
+            </Alert>
+        </Snackbar>
+    );
+}
+
+export default SuccessSnack;

--- a/ui/src/components/levels/Chart.jsx
+++ b/ui/src/components/levels/Chart.jsx
@@ -1,10 +1,13 @@
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import UplotReact from 'uplot-react';
 import 'uplot/dist/uPlot.min.css';
+import {Alert} from "@mui/material";
 
 const Chart = ({options, levelsService, devices}) => {
+    const [connected, setConnected] = useState(true);
 
     useEffect(() => {
+        levelsService.setConnectedCallback(setConnected);
         levelsService.loadDevices(devices);
         levelsService.initWebsocket();
         return () => {
@@ -13,10 +16,17 @@ const Chart = ({options, levelsService, devices}) => {
     }, [levelsService]);
 
     return (
-        <UplotReact options={options}
-                    data={[]}
-                    onCreate={u => levelsService.setChart(u)}
-                    onDelete={u => levelsService.setChart(null)}/>
+        <>
+            {!connected && (
+                <Alert severity="warning" sx={{mb: 1}}>
+                    Levels WebSocket disconnected — reconnecting…
+                </Alert>
+            )}
+            <UplotReact options={options}
+                        data={[]}
+                        onCreate={u => levelsService.setChart(u)}
+                        onDelete={u => levelsService.setChart(null)}/>
+        </>
     );
 }
 

--- a/ui/src/components/main/Entry.jsx
+++ b/ui/src/components/main/Entry.jsx
@@ -140,7 +140,7 @@ const Uploader = ({
             {slotGroup}
             {gainControl}
             <Button variant="contained"
-                    startIcon={pending ? <CircularProgress size={24} color="inherit"/> : <PublishIcon fontSize="small"/>}
+                    startIcon={pending ? <CircularProgress size={24}/> : <PublishIcon fontSize="small"/>}
                     onClick={upload}>
                 Upload
             </Button>
@@ -148,7 +148,7 @@ const Uploader = ({
     );
 };
 
-const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotId, setError, setUploadPendingSlotId}) => {
+const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotId, setError, setSuccess, setUploadPendingSlotId}) => {
     const [uploadSlotId, setUploadSlotId] = useState(null);
     const [sendGain, setSendGain] = useState(false);
     const [pending, setPending] = useState(false);
@@ -192,6 +192,7 @@ const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotI
                     setPending(false);
                     if (setUploadPendingSlotId) setUploadPendingSlotId(null);
                     setDevice(device);
+                    if (setSuccess) setSuccess('Filter loaded');
                 } catch (e) {
                     setError(e);
                     setPending(false);

--- a/ui/src/components/main/Entry.jsx
+++ b/ui/src/components/main/Entry.jsx
@@ -140,7 +140,7 @@ const Uploader = ({
             {slotGroup}
             {gainControl}
             <Button variant="contained"
-                    startIcon={pending ? <CircularProgress size={24}/> : <PublishIcon fontSize="small"/>}
+                    startIcon={pending ? <CircularProgress size={24} color="inherit"/> : <PublishIcon fontSize="small"/>}
                     onClick={upload}>
                 Upload
             </Button>
@@ -148,7 +148,7 @@ const Uploader = ({
     );
 };
 
-const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotId, setError}) => {
+const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotId, setError, setUploadPendingSlotId}) => {
     const [uploadSlotId, setUploadSlotId] = useState(null);
     const [sendGain, setSendGain] = useState(false);
     const [pending, setPending] = useState(false);
@@ -183,16 +183,19 @@ const Entry = ({selectedDevice, selectedEntry, useWide, setDevice, selectedSlotI
                     }) : []
                 } : null;
                 setPending(true);
+                if (setUploadPendingSlotId) setUploadPendingSlotId(uploadSlotId);
                 try {
                     const call = gains
                         ? () => ezbeq.loadWithMV(selectedDevice.name, selectedEntry.id, uploadSlotId, gains)
                         : () => ezbeq.sendFilter(selectedDevice.name, selectedEntry.id, uploadSlotId);
                     const device = await call();
                     setPending(false);
+                    if (setUploadPendingSlotId) setUploadPendingSlotId(null);
                     setDevice(device);
                 } catch (e) {
                     setError(e);
                     setPending(false);
+                    if (setUploadPendingSlotId) setUploadPendingSlotId(null);
                 }
             }
         }

--- a/ui/src/components/main/Footer.jsx
+++ b/ui/src/components/main/Footer.jsx
@@ -41,7 +41,7 @@ const Footer = ({meta}) => {
     if (meta || version) {
         const sha1 = meta && meta.version ? meta.version.substring(0, 7) : '';
         return (
-            <StyledGrid container justifyContent="space-around" gap={2} className={classes.noLeft}>
+            <StyledGrid container justifyContent="space-around" gap={2} className={classes.noLeft} sx={{mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider'}}>
                 <Grid>
                     <Typography variant={'caption'} color={'textSecondary'}>
                         {meta ? `cat: ${formatSeconds(meta.loaded)} / ${sha1}` : ''}

--- a/ui/src/components/main/Footer.jsx
+++ b/ui/src/components/main/Footer.jsx
@@ -41,15 +41,21 @@ const Footer = ({meta}) => {
     if (meta || version) {
         const sha1 = meta && meta.version ? meta.version.substring(0, 7) : '';
         return (
-            <StyledGrid container justifyContent="space-around" className={classes.noLeft}>
+            <StyledGrid container justifyContent="space-around" gap={2} className={classes.noLeft}>
                 <Grid>
                     <Typography variant={'caption'} color={'textSecondary'}>
-                        {meta ? `${formatSeconds(meta.loaded)} / ${sha1}` : ''}
+                        {meta ? `cat: ${formatSeconds(meta.loaded)} / ${sha1}` : ''}
                     </Typography>
                 </Grid>
                 <Grid>
                     <Typography variant={'caption'} color={'textSecondary'}>
-                        {version.version !== 'UNKNOWN' ? `v${version.version}` : version.version}
+                        {(() => {
+                            const gitRef = version.branch ? `${version.branch}@${version.sha || ''}` : version.sha || '';
+                            const v = version.version;
+                            const vStr = (v && v !== 'UNKNOWN') ? `v${v}` : (gitRef ? '' : (v || ''));
+                            const gitStr = gitRef ? ` git: ${gitRef}` : '';
+                            return vStr || gitStr ? `app: ${vStr}${gitStr}`.trim() : '';
+                        })()}
                     </Typography>
                 </Grid>
             </StyledGrid>

--- a/ui/src/components/main/Gain.jsx
+++ b/ui/src/components/main/Gain.jsx
@@ -1,201 +1,129 @@
-import React, {useEffect, useState} from 'react';
-import {styled} from '@mui/material/styles';
-import clsx from 'clsx';
+import React from 'react';
 import {
-    Button,
-    CircularProgress,
-    FormControl,
-    FormGroup,
+    Box,
+    Divider,
     IconButton,
-    InputAdornment,
-    TextField
+    Slider,
+    TextField,
+    Tooltip,
+    Typography
 } from "@mui/material";
-import PublishIcon from '@mui/icons-material/Publish';
 import VolumeOffIcon from '@mui/icons-material/VolumeOff';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 
-const PREFIX = 'Gain';
+const dp = (step) => step < 0.1 ? 2 : step < 1 ? 1 : 0;
 
-const classes = {
-    root: `${PREFIX}-root`,
-    padTop: `${PREFIX}-padTop`,
-    withoutLabel: `${PREFIX}-withoutLabel`,
-    sized: `${PREFIX}-sized`,
-    zeroPad: `${PREFIX}-zeroPad`,
-    tightPad: `${PREFIX}-tightPad`
-};
+const GainRow = ({label, minGain, maxGain, step, value, muted, savedValue, savedMuted, onValueChange, onValueCommit, onMuteToggle}) => {
+    const isDirty = parseFloat(value) !== parseFloat(savedValue) || muted !== savedMuted;
+    const numValue = parseFloat(value);
+    const isValid = !isNaN(numValue);
+    const decimals = dp(step);
 
-const Root = styled('div/')((
-    {
-        theme
-    }
-) => ({
-    [`& .${classes.padTop}`]: {
-        paddingTop: theme.spacing(1),
-        width: '100%'
-    },
-
-    [`& .${classes.withoutLabel}`]: {
-        marginTop: theme.spacing(1),
-    },
-
-    [`& .${classes.sized}`]: {
-        margin: theme.spacing(0.5),
-        width: '22.5%'
-    },
-
-    [`& .${classes.zeroPad}`]: {
-        padding: 0
-    },
-
-    [`& .${classes.tightPad}`]: {
-        paddingRight: 0
-    }
-}));
-
-const TightTextField = TextField;
-
-const GainInput = ({fieldName, helpText, minGain, maxGain, step, dp, savedValues, values, setMV, setMute}) => {
-
-    const decimalSeparator = (1.1).toLocaleString().substring(1, 2);
-    const oneNum = '^[0-9]$';
-    const sepMatcher = decimalSeparator === '.' ? /\./g : new RegExp(decimalSeparator, 'g');
-    const roundFactor = 1 / step;
-    const delta = (parseFloat(values.mv) !== parseFloat(savedValues.mv) || values.mute !== savedValues.mute);
-    const setConstrainedMV = (f, dp) => {
-        const rounded = Math.round(f * (roundFactor)) / roundFactor;
-        if (rounded > maxGain) {
-            setMV(maxGain.toFixed(dp));
-        } else if (rounded < minGain) {
-            setMV(minGain.toFixed(dp));
-        } else {
-            setMV(rounded.toFixed(dp));
-        }
-    }
-    const interpretMV = (txt) => {
-        if (txt) {
-            if (txt === '-') {
-                setMV(txt);
-            } else if (maxGain === 0 && txt.match(oneNum)) {
-                setMV(`-${txt}`);
-            } else {
-                const dotCount = (txt.match(sepMatcher) || []).length;
-                if (dotCount === 0) {
-                    const f = parseFloat(txt);
-                    if (!isNaN(f)) {
-                        setConstrainedMV(f, 0);
-                    }
-                } else if (dotCount === 1) {
-                    if (txt.charAt(txt.length - 1) === decimalSeparator) {
-                        setMV(txt);
-                    } else {
-                        const f = parseFloat(txt);
-                        if (!isNaN(f)) {
-                            if (dp > 1) {
-                                const oldValue = values.mv;
-                                if (Math.abs(f) < Math.abs(oldValue) || txt.length < oldValue.toString().length) {
-                                    setMV(txt);
-                                } else {
-                                    setConstrainedMV(f, dp);
-                                }
-                            } else {
-                                setConstrainedMV(f, dp);
-                            }
-                        }
-                    }
-                }
-            }
-        } else {
-            setMV('');
-        }
-    };
     return (
-        <TightTextField
-            className={clsx(classes.sized, classes.withoutLabel, classes.tightPad)}
-            variant={'outlined'}
-            id={fieldName}
-            value={values.mv}
-            onChange={e => interpretMV(e.target.value)}
-            aria-describedby={`${fieldName}-helper-text`}
-            slotProps={{
-                input: {
-                    endAdornment: (
-                        <InputAdornment position="end">
-                            <IconButton
-                                aria-label="mute channel"
-                                onClick={e => setMute(!values.mute)}
-                                className={classes.zeroPad}
-                                color={delta ? 'secondary' : 'default'}
-                                size="large">
-                                {values.mute ? <VolumeOffIcon fontSize="small"/> :
-                                    <VolumeUpIcon fontSize="small"/>}
-                            </IconButton>
-                        </InputAdornment>
-                    )
-                },
-                htmlInput: {
-                    'aria-label': fieldName,
-                    pattern: '',
+        <Box sx={{display: 'flex', alignItems: 'center', gap: 1, mb: 0.5}}>
+            <Typography variant="body2" sx={{minWidth: 72, color: 'text.secondary', fontSize: '0.8rem'}}>
+                {label}
+            </Typography>
+            <Slider
+                size="small"
+                min={minGain}
+                max={maxGain}
+                step={step}
+                value={isValid ? numValue : minGain}
+                onChange={(_, v) => onValueChange(v.toFixed(decimals))}
+                onChangeCommitted={(_, v) => onValueCommit(v.toFixed(decimals))}
+                sx={{flex: 1, color: isDirty ? 'secondary.main' : 'primary.main'}}
+                disabled={muted}
+            />
+            <TextField
+                size="small"
+                value={value}
+                onChange={e => onValueChange(e.target.value)}
+                onBlur={e => {
+                    const f = parseFloat(e.target.value);
+                    if (!isNaN(f)) onValueCommit(Math.min(maxGain, Math.max(minGain, f)).toFixed(decimals));
+                }}
+                inputProps={{
+                    style: {textAlign: 'right', width: '4.5em', padding: '4px 6px'},
                     inputMode: 'numeric'
-                }
-            }}
-            margin={'dense'}
-            size={'small'}
-            label={helpText}
-            classes={{
-                root: classes.root
-            }}/>
+                }}
+                sx={{'& .MuiOutlinedInput-root': {color: isDirty ? 'secondary.main' : 'inherit'}}}
+                variant="outlined"
+            />
+            <Typography variant="caption" sx={{color: 'text.secondary', minWidth: '2em'}}>dB</Typography>
+            <Tooltip title={muted ? 'Unmute' : 'Mute'}>
+                <IconButton
+                    size="small"
+                    onClick={() => onMuteToggle(!muted)}
+                    sx={{color: muted ? 'error.main' : 'action.active'}}
+                >
+                    {muted ? <VolumeOffIcon fontSize="small"/> : <VolumeUpIcon fontSize="small"/>}
+                </IconButton>
+            </Tooltip>
+        </Box>
     );
 };
 
-const Gain = ({selectedSlotId, deviceGains, gains, updateGain, sendGains, isActive}) => {
+const Gain = ({selectedSlotId, deviceGains, gains, updateGain, commitGain}) => {
+    const hasInputChannels = gains.gains && gains.gains.length > 0;
+    const hasOutputChannels = gains.output_gains && gains.output_gains.length > 0;
 
-    const [valid, setValid] = useState(true);
-    useEffect(() => {
-        setValid(isNaN(gains.master_mv) || gains.gains.some(g => isNaN(g.value)));
-    }, [gains]);
-    if (selectedSlotId !== null) {
-        return (
-            <div className={classes.padTop}>
-                <FormControl variant="standard" component="fieldset">
-                    <FormGroup row>
-                        <GainInput fieldName='master-gain' helpText='Master'
-                                   minGain={-127} maxGain={0} step={0.5} dp={1}
-                                   savedValues={{mv: deviceGains.master_mv, mute: deviceGains.master_mute}}
-                                   values={{mv: gains.master_mv, mute: gains.master_mute}}
-                                   setMV={v => updateGain('master', 'mv', v)}
-                                   setMute={v => updateGain('master', 'mute', v)}/>
-                        {
-                            gains.gains.map((g, i) =>
-                                <GainInput key={`input${g.id}`}
-                                           fieldName={`input${g.id}-gain`}
-                                           helpText={`Input ${g.id}`}
-                                           minGain={-72} maxGain={12} step={0.25} dp={2}
-                                           savedValues={{
-                                               mv: deviceGains.gains[i].value,
-                                               mute: deviceGains.mutes[i].value
-                                           }}
-                                           values={{mv: gains.gains[i].value, mute: gains.mutes[i].value}}
-                                           setMV={v => updateGain(g.id, 'mv', v)}
-                                           setMute={v => updateGain(g.id, 'mute', v)}/>
-                            )
-                        }
-                        <Button variant="outlined"
-                                size="small"
-                                color="primary"
-                                className={classes.sized}
-                                onClick={() => sendGains(selectedSlotId, gains)}
-                                disabled={valid}
-                                startIcon={isActive() ? <CircularProgress size={24}/> :
-                                    <PublishIcon fontSize="small"/>}>
-                            Apply
-                        </Button>
-                    </FormGroup>
-                </FormControl>
-            </div>
-        );
-    }
-    return <div/>;
+    if (!gains.hasOwnProperty('master_mv')) return <div/>;
+
+    return (
+        <Box sx={{pt: 1, px: 0.5, width: '100%'}}>
+            <GainRow
+                label="Master"
+                minGain={-127} maxGain={0} step={0.5}
+                value={gains.master_mv}
+                muted={gains.master_mute}
+                savedValue={deviceGains.master_mv}
+                savedMuted={deviceGains.master_mute}
+                onValueChange={v => updateGain('master', 'mv', v)}
+                onValueCommit={v => commitGain('master', 'mv', v)}
+                onMuteToggle={v => commitGain('master', 'mute', v)}
+            />
+
+            {selectedSlotId !== null && (hasInputChannels || hasOutputChannels) && (
+                <>
+                    <Divider sx={{my: 0.5}}/>
+                    {hasInputChannels && gains.gains.map((g, i) => (
+                        <GainRow
+                            key={`input-${g.id}`}
+                            label={`Input ${g.id}`}
+                            minGain={-72} maxGain={12} step={0.25}
+                            value={g.value}
+                            muted={gains.mutes[i]?.value ?? false}
+                            savedValue={deviceGains.gains[i]?.value ?? 0}
+                            savedMuted={deviceGains.mutes[i]?.value ?? false}
+                            onValueChange={v => updateGain(g.id, 'mv', v)}
+                            onValueCommit={v => commitGain(g.id, 'mv', v)}
+                            onMuteToggle={v => commitGain(g.id, 'mute', v)}
+                        />
+                    ))}
+                    {hasOutputChannels && (
+                        <>
+                            {hasInputChannels && <Divider sx={{my: 0.5}}/>}
+                            {gains.output_gains.map((g, i) => (
+                                <GainRow
+                                    key={`output-${g.id}`}
+                                    label={`Output ${g.id}`}
+                                    minGain={-72} maxGain={12} step={0.25}
+                                    value={g.value}
+                                    muted={gains.output_mutes[i]?.value ?? false}
+                                    savedValue={deviceGains.output_gains?.[i]?.value ?? 0}
+                                    savedMuted={deviceGains.output_mutes?.[i]?.value ?? false}
+                                    onValueChange={v => updateGain(`out_${g.id}`, 'mv', v)}
+                                    onValueCommit={v => commitGain(`out_${g.id}`, 'mv', v)}
+                                    onMuteToggle={v => commitGain(`out_${g.id}`, 'mute', v)}
+                                />
+                            ))}
+                        </>
+                    )}
+                </>
+            )}
+        </Box>
+    );
 };
 
 export default Gain;

--- a/ui/src/components/main/Slots.jsx
+++ b/ui/src/components/main/Slots.jsx
@@ -94,7 +94,7 @@ const Slot = ({selected, slot, onSelect, isPending, onClear}) => {
     );
 };
 
-const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDriven, setError}) => {
+const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDriven, setError, uploadPendingSlotId}) => {
 
     const [pending, setPending] = useState([]);
     const [currentGains, setCurrentGains] = useState(defaultGain);
@@ -185,7 +185,7 @@ const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDrive
     };
 
     const isPending = (slotId) => {
-        return getCurrentState(pending, 'clear', slotId) === 1 || getCurrentState(pending, 'activate', slotId) === 1;
+        return getCurrentState(pending, 'clear', slotId) === 1 || getCurrentState(pending, 'activate', slotId) === 1 || uploadPendingSlotId === slotId;
     };
 
     const rows = chunk(selectedDevice && selectedDevice.hasOwnProperty('slots') ? selectedDevice.slots : [], 2);

--- a/ui/src/components/main/Slots.jsx
+++ b/ui/src/components/main/Slots.jsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material/styles';
-import React, {useCallback, useEffect, useState} from "react";
+import React, {useCallback, useEffect, useRef, useState} from "react";
 import ezbeq from "../../services/ezbeq";
 import {CircularProgress, Grid, IconButton, Paper} from "@mui/material";
 import Box from '@mui/material/Box';
@@ -65,7 +65,7 @@ const getCurrentState = (active, label, slotId) => {
 const chunk = (arr, size) => arr.reduce((chunks, el, i) => (i % size ? chunks[chunks.length - 1].push(el) : chunks.push([el])) && chunks, []);
 
 const defaultGain = {
-    master_mv: 0.0, master_mute: false, gains: [], mutes: []
+    master_mv: 0.0, master_mute: false, gains: [], mutes: [], output_gains: [], output_mutes: []
 };
 
 const Slot = ({selected, slot, onSelect, isPending, onClear}) => {
@@ -94,60 +94,67 @@ const Slot = ({selected, slot, onSelect, isPending, onClear}) => {
     );
 };
 
-const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDriven, setError, uploadPendingSlotId}) => {
+const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDriven, setError, setSuccess, uploadPendingSlotId}) => {
 
     const [pending, setPending] = useState([]);
     const [currentGains, setCurrentGains] = useState(defaultGain);
-    const [deviceGains, setDeviceGains] = useState({});
+    const [deviceGains, setDeviceGains] = useState({...defaultGain});
+    const prevDeviceNameRef = useRef(null);
+    const prevSlotIdRef = useRef(null);
 
-    const updateGain = useCallback((parent, key, value) => {
-        const newGains = JSON.parse(JSON.stringify(currentGains));
-        let updated = true;
+    const applyGainChange = (gains, parent, key, value) => {
+        const newGains = JSON.parse(JSON.stringify(gains));
+        const isOutput = typeof parent === 'string' && parent.startsWith('out_');
+        const channelId = isOutput ? parent.slice(4) : parent;
         if (key === 'mv') {
-            if (parent === 'master') {
-                newGains.master_mv = value;
-            } else {
-                const match = newGains.gains.find(e => e.id === parent);
-                if (match) {
-                    match.value = value
-                } else {
-                    updated = false;
-                }
-            }
+            if (parent === 'master') newGains.master_mv = value;
+            else if (isOutput) { const m = newGains.output_gains.find(e => e.id === channelId); if (m) m.value = value; }
+            else { const m = newGains.gains.find(e => e.id === parent); if (m) m.value = value; }
         } else if (key === 'mute') {
-            if (parent === 'master') {
-                newGains.master_mute = value;
-            } else {
-                const match = newGains.mutes.find(e => e.id === parent);
-                if (match) {
-                    match.value = value
-                } else {
-                    updated = false;
-                }
-            }
-        } else {
-            updated = false;
+            if (parent === 'master') newGains.master_mute = value;
+            else if (isOutput) { const m = newGains.output_mutes.find(e => e.id === channelId); if (m) m.value = value; }
+            else { const m = newGains.mutes.find(e => e.id === parent); if (m) m.value = value; }
         }
-        if (updated) {
-            setCurrentGains(newGains);
-        } else {
-            console.warn(`Ignoring unknown update : ${parent}.${key}=${value}`);
-        }
-    }, [currentGains, setCurrentGains]);
+        return newGains;
+    };
 
-    // reset gain on slot (de)select or device update
+    // local state only — for smooth slider drag display
+    const updateGain = useCallback((parent, key, value) => {
+        setCurrentGains(g => applyGainChange(g, parent, key, value));
+    }, []);
+
+    // update state AND send only the changed field to device
+    const commitGain = useCallback((parent, key, value) => {
+        setCurrentGains(g => applyGainChange(g, parent, key, value));
+        ezbeq.patchSingle(selectedDevice.name, parent, key, value, selectedSlotId)
+            .catch(e => setError(e));
+    }, [selectedSlotId, selectedDevice]);
+
+    // sync gains from device state
     useEffect(() => {
         if (selectedDevice) {
             const gain = {...defaultGain};
-            gain.master_mv = selectedDevice.masterVolume;
-            gain.master_mute = selectedDevice.mute;
-            if (selectedSlotId && selectedDevice && selectedDevice.hasOwnProperty('slots')) {
+            gain.master_mv = selectedDevice.masterVolume ?? 0.0;
+            gain.master_mute = selectedDevice.mute ?? false;
+            if (selectedSlotId && selectedDevice.hasOwnProperty('slots')) {
                 const slot = selectedDevice.slots.find(s => s.id === selectedSlotId);
-                gain.gains = slot.hasOwnProperty('gains') ? slot.gains : [];
-                gain.mutes = slot.hasOwnProperty('mutes') ? slot.mutes : [];
+                if (slot) {
+                    gain.gains = slot.hasOwnProperty('gains') ? slot.gains : [];
+                    gain.mutes = slot.hasOwnProperty('mutes') ? slot.mutes : [];
+                    gain.output_gains = slot.hasOwnProperty('outputGains') ? slot.outputGains : [];
+                    gain.output_mutes = slot.hasOwnProperty('outputMutes') ? slot.outputMutes : [];
+                }
             }
             setDeviceGains(gain);
-            setCurrentGains(gain);
+            // Only reset the user-facing controls when the device or slot actually changes,
+            // not on every WebSocket update (which would fight the user's in-progress changes)
+            const deviceChanged = selectedDevice.name !== prevDeviceNameRef.current;
+            const slotChanged = selectedSlotId !== prevSlotIdRef.current;
+            if (deviceChanged || slotChanged) {
+                setCurrentGains(gain);
+                prevDeviceNameRef.current = selectedDevice.name;
+                prevSlotIdRef.current = selectedSlotId;
+            }
         }
     }, [selectedDevice, selectedSlotId]);
 
@@ -172,12 +179,10 @@ const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDrive
         }
     };
 
-    const sendGainToDevice = (slotId, gains) => {
-        trackDeviceUpdate('gain', slotId, () => ezbeq.setGains(selectedDevice.name, slotId, gains));
-    };
-
-    const clearDeviceSlot = (slotId) => {
-        trackDeviceUpdate('clear', slotId, () => ezbeq.clearSlot(selectedDevice.name, slotId));
+const clearDeviceSlot = (slotId) => {
+        trackDeviceUpdate('clear', slotId, () => ezbeq.clearSlot(selectedDevice.name, slotId), () => {
+            if (setSuccess) setSuccess('Slot cleared');
+        });
     };
 
     const activateSlot = (slotId) => {
@@ -203,13 +208,13 @@ const Slots = ({selectedDevice, selectedSlotId, useWide, setDevice, setUserDrive
         </Grid>
     );
 
+    // Show gain panel whenever device supports it (not gated on slot selection)
     if (selectedDevice && selectedDevice.hasOwnProperty('masterVolume')) {
         const gain = <Gain selectedSlotId={selectedSlotId}
                            deviceGains={deviceGains}
                            gains={currentGains}
                            updateGain={updateGain}
-                           sendGains={sendGainToDevice}
-                           isActive={() => getCurrentState(pending, 'gain', selectedSlotId) === 1}/>;
+                           commitGain={commitGain}/>;
         if (useWide) {
             return (
                 <Box sx={{flexGrow: 1}}>

--- a/ui/src/components/main/WhatsNew.jsx
+++ b/ui/src/components/main/WhatsNew.jsx
@@ -1,0 +1,67 @@
+import React, {useState} from 'react';
+import Drawer from '@mui/material/Drawer';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+
+const WhatsNew = ({onClose, entries, lastChecked, onSelect, initialMode}) => {
+    const [mode, setMode] = useState(initialMode ?? 'new');
+
+    const visible = mode === 'new'
+        ? entries.filter(e => Math.max(e.created_at || 0, e.updated_at || 0) >= lastChecked)
+        : entries;
+
+    return (
+        <Drawer anchor="left" open={true} onClose={onClose} transitionDuration={0}
+                variant="persistent"
+                slotProps={{paper: {sx: {top: {xs: '56px', sm: '64px'}, height: {xs: 'calc(100% - 56px)', sm: 'calc(100% - 64px)'}}}}}>
+
+            <Box sx={{width: {xs: '100vw', sm: 400}, display: 'flex', flexDirection: 'column', height: '100%'}}>
+                <Box sx={{display: 'flex', alignItems: 'center', p: 1.5, gap: 1}}>
+                    <Typography variant="h6" sx={{flexGrow: 1}}>What's New</Typography>
+                    <ToggleButtonGroup size="small" value={mode} exclusive onChange={(_, v) => v && setMode(v)}>
+                        <ToggleButton value="new">New</ToggleButton>
+                        <ToggleButton value="recent">Recent</ToggleButton>
+                    </ToggleButtonGroup>
+                    <IconButton size="small" onClick={onClose}><CloseIcon/></IconButton>
+                </Box>
+                <Divider/>
+                {visible.length === 0
+                    ? <Box sx={{p: 3}}><Typography color="text.secondary">
+                        {mode === 'new' ? 'Nothing new since your last check.' : 'No recent titles in the last 2 weeks.'}
+                    </Typography></Box>
+                    : <List dense disablePadding sx={{overflowY: 'auto', flexGrow: 1}}>
+                        {visible.map((entry, idx) => (
+                            <React.Fragment key={entry.id ?? idx}>
+                                <ListItem button onClick={() => onSelect(entry.id)} sx={{flexDirection: 'column', alignItems: 'flex-start', py: 1.5, px: 2, gap: 0.5, cursor: 'pointer'}}>
+                                    <Typography variant="body1" sx={{fontWeight: 500, lineHeight: 1.3}}>
+                                        {entry.formattedTitle}{entry.year ? ` (${entry.year})` : ''}
+                                    </Typography>
+                                    <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.5}}>
+                                        {entry.freshness === 'Fresh'
+                                            ? <Chip label="New" size="small" color="success" variant="outlined"/>
+                                            : <Chip label="Updated" size="small" color="info" variant="outlined"/>}
+                                        {entry.author && <Chip label={entry.author} size="small" variant="outlined"/>}
+                                        {entry.audioTypes && entry.audioTypes.map(t => (
+                                            <Chip key={t} label={t} size="small" variant="outlined" sx={{opacity: 0.75}}/>
+                                        ))}
+                                    </Box>
+                                </ListItem>
+                                {idx < visible.length - 1 && <Divider component="li"/>}
+                            </React.Fragment>
+                        ))}
+                    </List>
+                }
+            </Box>
+        </Drawer>
+    );
+};
+
+export default WhatsNew;

--- a/ui/src/components/main/index.jsx
+++ b/ui/src/components/main/index.jsx
@@ -1,5 +1,6 @@
 import Header from "../Header";
 import Filter from "./Filter";
+import WhatsNew from "./WhatsNew";
 import {Grid} from "@mui/material";
 import React, {useEffect, useState} from "react";
 import {pushData, useLocalStorage} from "../../services/util";
@@ -8,11 +9,15 @@ import Catalogue from "./Catalogue";
 import Entry from "./Entry";
 import Search from "./Search";
 import Footer from "./Footer";
+import ezbeq from "../../services/ezbeq";
+
+const TWO_WEEKS_AGO_SECS = () => Math.floor(Date.now() / 1000) - 2 * 7 * 24 * 60 * 60;
 
 const MainView = ({
                       entries,
                       availableDevices,
                       setErr,
+                      setSuccess,
                       replaceDevice,
                       selectedDeviceName,
                       setSelectedDeviceName,
@@ -35,6 +40,26 @@ const MainView = ({
     const [userDriven, setUserDriven] = useState(false);
     const [filteredEntries, setFilteredEntries] = useState([]);
     const [uploadPendingSlotId, setUploadPendingSlotId] = useState(null);
+
+    // whats new
+    const [lastChecked, setLastChecked] = useLocalStorage('whatsNewLastChecked', TWO_WEEKS_AGO_SECS());
+    const [recentEntries, setRecentEntries] = useState([]);
+    const [whatsNewOpen, setWhatsNewOpen] = useState(false);
+
+    useEffect(() => {
+        pushData(setRecentEntries, () => ezbeq.getWhatsNew(), setErr);
+    }, [meta]);
+
+    const newCount = recentEntries.filter(e => Math.max(e.created_at || 0, e.updated_at || 0) >= lastChecked).length;
+
+    const openWhatsNew = () => {
+        if (whatsNewOpen) {
+            setWhatsNewOpen(false);
+        } else {
+            setWhatsNewOpen(true);
+            setLastChecked(Math.floor(Date.now() / 1000));
+        }
+    };
 
     const toggleShowFilters = () => {
         setShowFilters((prev) => !prev);
@@ -104,6 +129,7 @@ const MainView = ({
                            setUserDriven={setUserDriven}
                            setDevice={d => replaceDevice(d)}
                            setError={setErr}
+                           setSuccess={setSuccess}
                            uploadPendingSlotId={uploadPendingSlotId}/>;
     const catalogue = <Catalogue entries={filteredEntries}
                                  setSelectedEntryId={setSelectedEntryId}
@@ -116,6 +142,7 @@ const MainView = ({
                          setDevice={d => replaceDevice(d)}
                          selectedSlotId={selectedSlotId}
                          setError={setErr}
+                         setSuccess={setSuccess}
                          setUploadPendingSlotId={setUploadPendingSlotId}/>;
     const footer = <Footer meta={meta}/>;
     return (
@@ -124,12 +151,18 @@ const MainView = ({
                     setSelectedDeviceName={setSelectedDeviceName}
                     selectedDeviceName={selectedDeviceName}
                     selectedNav={selectedNav}
-                    setSelectedNav={setSelectedNav}>
+                    setSelectedNav={setSelectedNav}
+                    whatsNewCount={newCount}
+                    onWhatsNewOpen={openWhatsNew}>
                 <Search txtFilter={txtFilter}
                         setTxtFilter={setTxtFilter}
                         showFilters={showFilters}
                         toggleShowFilters={toggleShowFilters}/>
             </Header>
+            {whatsNewOpen && <WhatsNew onClose={() => setWhatsNewOpen(false)} entries={recentEntries}
+                      lastChecked={lastChecked}
+                      initialMode={newCount > 0 ? 'new' : 'recent'}
+                      onSelect={id => setSelectedEntryId(id)}/>}
             <Filter visible={showFilters}
                     selectedAudioTypes={selectedAudioTypes}
                     setSelectedAudioTypes={setSelectedAudioTypes}

--- a/ui/src/components/main/index.jsx
+++ b/ui/src/components/main/index.jsx
@@ -34,6 +34,7 @@ const MainView = ({
     const [selectedEntryId, setSelectedEntryId] = useState(-1);
     const [userDriven, setUserDriven] = useState(false);
     const [filteredEntries, setFilteredEntries] = useState([]);
+    const [uploadPendingSlotId, setUploadPendingSlotId] = useState(null);
 
     const toggleShowFilters = () => {
         setShowFilters((prev) => !prev);
@@ -102,7 +103,8 @@ const MainView = ({
                            setSelectedSlotId={setSelectedSlotId}
                            setUserDriven={setUserDriven}
                            setDevice={d => replaceDevice(d)}
-                           setError={setErr}/>;
+                           setError={setErr}
+                           uploadPendingSlotId={uploadPendingSlotId}/>;
     const catalogue = <Catalogue entries={filteredEntries}
                                  setSelectedEntryId={setSelectedEntryId}
                                  selectedEntryId={selectedEntryId}
@@ -113,7 +115,8 @@ const MainView = ({
                          useWide={useWide}
                          setDevice={d => replaceDevice(d)}
                          selectedSlotId={selectedSlotId}
-                         setError={setErr}/>;
+                         setError={setErr}
+                         setUploadPendingSlotId={setUploadPendingSlotId}/>;
     const footer = <Footer meta={meta}/>;
     return (
         <>

--- a/ui/src/components/minidsp/index.jsx
+++ b/ui/src/components/minidsp/index.jsx
@@ -1,10 +1,10 @@
 import Header from "../Header";
 import {styled} from '@mui/material/styles';
-import React, {useEffect, useState} from "react";
+import React, {useCallback, useEffect, useRef, useState} from "react";
 import {
     Button,
     Chip,
-    CircularProgress,
+    Divider,
     FormControl,
     FormControlLabel,
     Grid,
@@ -14,10 +14,13 @@ import {
     Select,
     Switch,
     TextField,
+    Typography,
 } from "@mui/material";
+import Box from "@mui/material/Box";
 import PublishIcon from "@mui/icons-material/Publish";
 import ezbeq from "../../services/ezbeq";
 import {useLocalStorage} from "../../services/util";
+import Gain from "../main/Gain";
 
 const PREFIX = 'Minidsp';
 
@@ -28,7 +31,6 @@ const classes = {
     root: `${PREFIX}-root`
 };
 
-// TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
 const Root = styled('div')((
     {
         theme
@@ -117,6 +119,10 @@ const SelectableSlots = ({
     );
 };
 
+const defaultGain = {
+    master_mv: 0.0, master_mute: false, gains: [], mutes: [], output_gains: [], output_mutes: []
+};
+
 const Minidsp = ({
                      availableDevices,
                      setSelectedDeviceName,
@@ -137,6 +143,66 @@ const Minidsp = ({
     const [pending, setPending] = useState(false);
     const [inputChannels, setInputChannels] = useState([]);
     const [outputChannels, setOutputChannels] = useState([]);
+
+    // volume control state
+    const [currentGains, setCurrentGains] = useState(defaultGain);
+    const [deviceGains, setDeviceGains] = useState({...defaultGain});
+    const prevDeviceNameRef = useRef(null);
+    const prevSlotIdRef = useRef(null);
+    const selectedDevice = availableDevices && selectedDeviceName ? availableDevices[selectedDeviceName] : null;
+
+    useEffect(() => {
+        if (selectedDevice) {
+            const gain = {...defaultGain};
+            gain.master_mv = selectedDevice.masterVolume ?? 0.0;
+            gain.master_mute = selectedDevice.mute ?? false;
+            if (selectedSlotId && selectedDevice.hasOwnProperty('slots')) {
+                const slot = selectedDevice.slots.find(s => s.id === selectedSlotId);
+                if (slot) {
+                    gain.gains = slot.hasOwnProperty('gains') ? slot.gains : [];
+                    gain.mutes = slot.hasOwnProperty('mutes') ? slot.mutes : [];
+                    gain.output_gains = slot.hasOwnProperty('outputGains') ? slot.outputGains : [];
+                    gain.output_mutes = slot.hasOwnProperty('outputMutes') ? slot.outputMutes : [];
+                }
+            }
+            setDeviceGains(gain);
+            const deviceChanged = selectedDevice.name !== prevDeviceNameRef.current;
+            const slotChanged = selectedSlotId !== prevSlotIdRef.current;
+            if (deviceChanged || slotChanged) {
+                setCurrentGains(gain);
+                prevDeviceNameRef.current = selectedDevice.name;
+                prevSlotIdRef.current = selectedSlotId;
+            }
+        }
+    }, [selectedDevice, selectedSlotId]);
+
+    const applyGainChange = (gains, parent, key, value) => {
+        const newGains = JSON.parse(JSON.stringify(gains));
+        const isOutput = typeof parent === 'string' && parent.startsWith('out_');
+        const channelId = isOutput ? parent.slice(4) : parent;
+        if (key === 'mv') {
+            if (parent === 'master') newGains.master_mv = value;
+            else if (isOutput) { const m = newGains.output_gains.find(e => e.id === channelId); if (m) m.value = value; }
+            else { const m = newGains.gains.find(e => e.id === parent); if (m) m.value = value; }
+        } else if (key === 'mute') {
+            if (parent === 'master') newGains.master_mute = value;
+            else if (isOutput) { const m = newGains.output_mutes.find(e => e.id === channelId); if (m) m.value = value; }
+            else { const m = newGains.mutes.find(e => e.id === parent); if (m) m.value = value; }
+        }
+        return newGains;
+    };
+
+    const updateGain = useCallback((parent, key, value) => {
+        setCurrentGains(g => applyGainChange(g, parent, key, value));
+    }, []);
+
+    const commitGain = useCallback((parent, key, value) => {
+        setCurrentGains(g => applyGainChange(g, parent, key, value));
+        if (selectedDevice) {
+            ezbeq.patchSingle(selectedDevice.name, parent, key, value, selectedSlotId)
+                .catch(e => setErr(e));
+        }
+    }, [selectedDevice, selectedSlotId]);
 
     const uploadTextCommands = async () => {
         setPending(true);
@@ -178,95 +244,119 @@ const Minidsp = ({
                     selectedNav={selectedNav}
                     setSelectedNav={setSelectedNav}
             />
-            <form className={classes.root} noValidate autoComplete="off">
-                <Grid container>
-                    <Grid container sx={{flexGrow: 1}} justifyContent="space-evenly" alignItems="center">
-                        <Grid>
-                            <FormControl variant="standard" className={classes.formControl}>
-                                <InputLabel id="config-label">Config</InputLabel>
-                                <Select
-                                    variant="standard"
-                                    labelId="config-label"
-                                    id="config"
-                                    value={config}
-                                    onChange={e => setConfig(e.target.value)}>
-                                    {[1, 2, 3, 4].map(s => <MenuItem key={s} value={s}>{s}</MenuItem>)}
-                                </Select>
-                            </FormControl>
+
+            {/* Volume Controls */}
+            {selectedDevice && selectedDevice.hasOwnProperty('masterVolume') && (
+                <Box sx={{px: 2, pt: 1}}>
+                    <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                        Volume
+                    </Typography>
+                    <Gain
+                        selectedSlotId={selectedSlotId}
+                        deviceGains={deviceGains}
+                        gains={currentGains}
+                        updateGain={updateGain}
+                        commitGain={commitGain}
+                    />
+                    <Divider sx={{mt: 2, mb: 1}}/>
+                </Box>
+            )}
+
+            {/* Biquad Upload */}
+            <Box sx={{px: 2}}>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                    Advanced
+                </Typography>
+                <form className={classes.root} noValidate autoComplete="off">
+                    <Grid container>
+                        <Grid container sx={{flexGrow: 1}} justifyContent="flex-start" alignItems="center" flexWrap="wrap">
+                            <Grid>
+                                <FormControl variant="standard" className={classes.formControl}>
+                                    <InputLabel id="config-label">Config</InputLabel>
+                                    <Select
+                                        variant="standard"
+                                        labelId="config-label"
+                                        id="config"
+                                        value={config}
+                                        onChange={e => setConfig(e.target.value)}>
+                                        {[1, 2, 3, 4].map(s => <MenuItem key={s} value={s}>{s}</MenuItem>)}
+                                    </Select>
+                                </FormControl>
+                            </Grid>
+                            {
+                                inputChannels.length > 0
+                                    ?
+                                    <Grid>
+                                        <SelectableSlots name={'Input'}
+                                                         key={'input'}
+                                                         onChange={e => setInputs(e.target.value.sort())}
+                                                         availableValues={inputChannels}
+                                                         values={inputs}
+                                                         theme={theme}/>
+                                    </Grid>
+                                    : null
+                            }
+                            {
+                                outputChannels.length > 0
+                                    ?
+                                    <Grid>
+                                        <SelectableSlots name={'Output'}
+                                                         key={'output'}
+                                                         onChange={e => setOutputs(e.target.value.sort())}
+                                                         availableValues={outputChannels}
+                                                         values={outputs}
+                                                         theme={theme}/>
+                                    </Grid>
+                                    : null
+                            }
+                            <Grid>
+                                <FormControlLabel
+                                    control={<Switch checked={overwrite}
+                                                     onChange={e => setOverwrite(e.target.checked)}
+                                                     color="default"
+                                                     name="overwrite"/>}
+                                    labelPlacement="top"
+                                    label="Overwrite?"/>
+                            </Grid>
+                            <Grid>
+                                <FormControl variant="standard" className={classes.formControl}>
+                                    <InputLabel id="mode-label">Mode</InputLabel>
+                                    <Select
+                                        variant="standard"
+                                        labelId="mode-label"
+                                        id="mode"
+                                        value={commandType}
+                                        onChange={e => setCommandType(e.target.value)}>
+                                        <MenuItem key={'bq'} value={'bq'}>Biquads</MenuItem>
+                                        <MenuItem key={'filt'} value={'filt'}>Filters</MenuItem>
+                                        <MenuItem key={'rs'} value={'rs'}>RS</MenuItem>
+                                    </Select>
+                                </FormControl>
+                            </Grid>
+                            <Grid>
+                                <Button variant="outlined"
+                                        color="primary"
+                                        onClick={uploadTextCommands}
+                                        disabled={commands.length === 0}
+                                        startIcon={pending ? <CircularProgress size={24}/> :
+                                            <PublishIcon fontSize="small"/>}>
+                                    Upload
+                                </Button>
+                            </Grid>
                         </Grid>
-                        {
-                            inputChannels.length > 0
-                                ?
-                                <Grid>
-                                    <SelectableSlots name={'Input'}
-                                                     key={'input'}
-                                                     onChange={e => setInputs(e.target.value.sort())}
-                                                     availableValues={inputChannels}
-                                                     values={inputs}
-                                                     theme={theme}/>
-                                </Grid>
-                                : null
-                        }
-                        {
-                            outputChannels.length > 0
-                                ?
-                                <Grid>
-                                    <SelectableSlots name={'Output'}
-                                                     key={'output'}
-                                                     onChange={e => setOutputs(e.target.value.sort())}
-                                                     availableValues={outputChannels}
-                                                     values={outputs}
-                                                     theme={theme}/>
-                                </Grid>
-                                : null
-                        }
-                        <Grid>
-                            <FormControlLabel
-                                control={<Switch checked={overwrite}
-                                                 onChange={e => setOverwrite(e.target.checked)}
-                                                 color="default"
-                                                 name="overwrite"/>}
-                                labelPlacement="top"
-                                label="Overwrite?"/>
-                        </Grid>
-                        <Grid>
-                            <FormControl variant="standard" className={classes.formControl}>
-                                <InputLabel id="mode-label">Mode</InputLabel>
-                                <Select
-                                    variant="standard"
-                                    labelId="mode-label"
-                                    id="mode"
-                                    value={commandType}
-                                    onChange={e => setCommandType(e.target.value)}>
-                                    <MenuItem key={'bq'} value={'bq'}>Biquads</MenuItem>
-                                    <MenuItem key={'filt'} value={'filt'}>Filters</MenuItem>
-                                    <MenuItem key={'rs'} value={'rs'}>RS</MenuItem>
-                                </Select>
-                            </FormControl>
-                        </Grid>
-                        <Grid>
-                            <Button variant="outlined"
-                                    color="primary"
-                                    onClick={uploadTextCommands}
-                                    disabled={commands.length === 0}
-                                    startIcon={pending ? <CircularProgress size={24}/> :
-                                        <PublishIcon fontSize="small"/>}>
-                                Upload
-                            </Button>
+                        <Grid container sx={{flexGrow: 1, mt: 1}}>
+                            <TextField id="commands"
+                                       label={commandType === 'bq' ? 'Biquads' : commandType === 'filt' ? 'Filters' : 'Minidsp RS'}
+                                       multiline
+                                       minRows={10}
+                                       fullWidth
+                                       value={commands}
+                                       onChange={e => setCommands(e.target.value)}
+                                       variant="outlined"/>
                         </Grid>
                     </Grid>
-                    <Grid container sx={{flexGrow: 1}}>
-                        <TextField id="commands"
-                                   label={commandType === 'bq' ? 'Biquads' : commandType === 'filt' ? 'Filters' : 'Minidsp RS'}
-                                   multiline
-                                   rows={26}
-                                   fullWidth
-                                   value={commands}
-                                   onChange={e => setCommands(e.target.value)}
-                                   variant="outlined"/>
-                    </Grid>
-                </Grid>
-            </form>
+                </form>
+            </Box>
         </Root>
     );
 }

--- a/ui/src/services/ezbeq.js
+++ b/ui/src/services/ezbeq.js
@@ -141,6 +141,27 @@ class EzBeqService {
         return await this.doPatch(device, this.createPatchPayload(slot, gains));
     };
 
+    // Send only the single changed field rather than all values
+    patchSingle = async (device, parent, key, value, slotId) => {
+        return await this.doPatch(device, this.buildTargetedPayload(parent, key, value, slotId));
+    };
+
+    buildTargetedPayload = (parent, key, value, slotId) => {
+        if (parent === 'master') {
+            if (key === 'mv') return {masterVolume: parseFloat(value)};
+            if (key === 'mute') return {mute: Boolean(value)};
+        }
+        const isOutput = typeof parent === 'string' && parent.startsWith('out_');
+        const channelId = isOutput ? parent.slice(4) : parent;
+        const slot = {id: String(slotId)};
+        if (key === 'mv') {
+            slot[isOutput ? 'outputGains' : 'gains'] = [{id: String(channelId), value: parseFloat(value)}];
+        } else if (key === 'mute') {
+            slot[isOutput ? 'outputMutes' : 'mutes'] = [{id: String(channelId), value: Boolean(value)}];
+        }
+        return {slots: [slot]};
+    };
+
     doPatch = async(device, payload) => {
         const response = await fetch(`${API_PREFIX}/3/devices/${device}`, {
             method: 'PATCH',
@@ -170,16 +191,29 @@ class EzBeqService {
         if (gains.hasOwnProperty('mutes')) {
             slot.mutes = gains.mutes.map(g => ({id: String(g.id), value: Boolean(g.value)}));
         }
-        if (entryId) {
-            payload.slots = [Object.assign({}, slot, {entry: entryId})]
-        } else {
-            payload.slots = [slot];
+        if (gains.hasOwnProperty('output_gains') && gains.output_gains.length > 0) {
+            slot.outputGains = gains.output_gains.map(g => ({id: String(g.id), value: parseFloat(g.value)}));
+        }
+        if (gains.hasOwnProperty('output_mutes') && gains.output_mutes.length > 0) {
+            slot.outputMutes = gains.output_mutes.map(g => ({id: String(g.id), value: Boolean(g.value)}));
+        }
+        if (slotId !== null && slotId !== undefined) {
+            if (entryId) {
+                payload.slots = [Object.assign({}, slot, {entry: entryId})]
+            } else {
+                payload.slots = [slot];
+            }
         }
         return payload;
     };
 
     loadWithMV = async (device, id, slot, gains) => {
         return await this.sendFilter(device, id, slot, gains);
+    };
+
+    getWhatsNew = (since) => {
+        const url = since ? `whats-new?since=${since}` : 'whats-new';
+        return this.doGet(url);
     };
 
     getDevices = async () => {

--- a/ui/src/services/levels.js
+++ b/ui/src/services/levels.js
@@ -14,6 +14,11 @@ class LevelsService {
         this.activeDuration = 60;
         this.dataByDeviceName = {};
         this.seriesDirty = true;
+        this.reconnectDelay = 1000;
+        this.maxReconnectDelay = 30000;
+        this.reconnectTimer = null;
+        this.intentionallyClosed = false;
+        this.setConnected = null;
         this.colours = [
             theme.palette.primary.light,
             theme.palette.secondary.light,
@@ -109,6 +114,10 @@ class LevelsService {
         }
     };
 
+    setConnectedCallback = (cb) => {
+        this.setConnected = cb;
+    };
+
     initWebsocket = () => {
         if (this.ws && this.ws.readyState <= 1) {
             console.warn(`Connection to ${this.url} is already open`);
@@ -119,10 +128,17 @@ class LevelsService {
             };
             this.ws.onopen = e => {
                 console.log(`Connected to ${this.url}`);
+                this.reconnectDelay = 1000;
+                if (this.setConnected) this.setConnected(true);
                 this.devices.forEach(d => this.ws.send(`subscribe levels ${d}`));
             }
             this.ws.onclose = e => {
                 console.log(`Closed connection to ${this.url} - ${e.code}`);
+                if (!this.intentionallyClosed) {
+                    if (this.setConnected) this.setConnected(false);
+                    this.reconnectTimer = setTimeout(() => this.initWebsocket(), this.reconnectDelay);
+                    this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.maxReconnectDelay);
+                }
             }
             this.ws.onmessage = e => {
                 const msg = JSON.parse(e.data)
@@ -188,6 +204,11 @@ class LevelsService {
     };
 
     close = () => {
+        this.intentionallyClosed = true;
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
         if (this.ws && this.ws.readyState === 1) {
             console.log(`Closing connection to ${this.url}`);
             this.ws.close();

--- a/ui/src/services/state.js
+++ b/ui/src/services/state.js
@@ -29,7 +29,11 @@ class StateService {
                     this.replaceDevice(payload.data);
                     break;
                 case 'Error':
-                    this.setErr(new Error(payload.data));
+                    const err = new Error(payload.data);
+                    if (payload.persistent) {
+                        err.persistent = true;
+                    }
+                    this.setErr(err);
                     break;
                 case 'Catalogue':
                     if (payload.data) {


### PR DESCRIPTION
Three related UI features, each in its own commit with tests.

depends on #87

## Commits

1. **Per-output volume/mute controls** — immediate-apply gain UI for individual output channels via v3 PATCH (`outputGains` / `outputMutes` on the slot model). Adds per-slot `output_gains` / `output_mutes` state and new minidsp commands (`output N gain/mute`). Tests: 57 parametrized cases covering all-channels + single-channel for mute and gain.
2. **What's New feed** — new `GET /api/1/whats-new?since=<unix>&limit=<n>` endpoint returning recently added/updated catalogue entries (default: last 2 weeks). Backed by a new query method on `Catalogues`. UI component under the header surfaces the feed. Tests: 5 cases covering since/limit semantics, default window, invalid params. Also fixed a `args.get('since') or default` bug where `since=0` was treated as unset.
3. **Auto-reconnect levels WebSocket** — levels service reconnects with exponential backoff when the WS drops; UI shows a banner during disconnect periods instead of silently stalling.

## Verified

- `poetry run pytest` — 802 passed (was 740; +62 new tests from commits 1 and 2)

Whats' new:
<img width="985" height="952" alt="Screenshot 2026-04-21 at 9 26 26 AM" src="https://github.com/user-attachments/assets/db526e92-ab8a-43b3-9e60-82971f38759a" />
