### PR TITLE
Add REAPER device support (via REAPER's Web Control interface + FabFilter Pro-Q 4)

### DIFF
--- a/docs/proq4_apply_filters.lua
+++ b/docs/proq4_apply_filters.lua
@@ -1,0 +1,464 @@
+-- proq4_apply_filters.lua
+--
+-- ==============================================================================
+-- OVERVIEW
+-- ==============================================================================
+-- Persistent ReaScript that bridges ezbeq (running the "reaper" device type,
+-- see ezbeq/reaper.py) to a single FabFilter Pro-Q 4 instance running inside
+-- this REAPER session.
+--
+-- Data flow:
+--   ezbeq (NixOS) --HTTP GET--> REAPER's Web Control interface --SET/EXTSTATE-->
+--   REAPER's ExtState memory (in-process, not persisted to disk) --polled by--> THIS SCRIPT
+--   --TrackFX_SetParam--> Pro-Q 4 VST3 instance
+--
+-- Why this approach instead of something simpler:
+--   - Pro-Q 4 has NO native EQ scripting API (REAPER's TrackFX_GetEQParam/
+--     TrackFX_SetEQParam only work with REAPER's own native ReaEQ plugin -
+--     confirmed empirically via proq4_dump.lua, which showed Pro-Q's params
+--     are not recognized by that API at all).
+--   - Pro-Q 4's automatable parameters are generic VST3 floats normalized to
+--     0..1, NOT real Hz/dB/Q values. The conversion formulas below were
+--     reverse-engineered from REAL data (see proq4_curve_sample.lua, which
+--     samples TrackFX_FormatParamValueNormalized() at many points and records
+--     the actual display string REAPER shows for each normalized value) -
+--     they are not assumed or guessed from documentation, because Pro-Q is
+--     closed-source and no such documentation exists publicly.
+--
+-- ==============================================================================
+-- VERIFIED CONVERSION FORMULAS (do not change without re-deriving from real
+-- proq4_curve_sample.lua output - these were confirmed against actual sampled
+-- data points, not derived analytically)
+-- ==============================================================================
+--   freq:  norm = log(freq/10) / log(3000)        valid range 10 Hz .. 30000 Hz
+--          (confirmed: norm=0.5 -> 547.7 Hz matches sampled data exactly)
+--   gain:  norm = (gain + 30) / 60                 linear, +/-30 dB
+--          (confirmed: norm=0.5 -> 0.00dB, norm=1.0 -> +30dB, exactly linear
+--          across all 20 sampled points)
+--   q:     norm = log(q/0.025) / log(1600)         valid range 0.025 .. 40
+--          (confirmed: norm=0.5 -> Q=1.000 matches sampled data exactly)
+--   shape: NOT a formula - Pro-Q packs 10 discrete shapes unevenly into the
+--          0..1 range (verified NOT evenly spaced - e.g. "Bell" only occupies
+--          roughly 0..0.05 while "Notch" occupies roughly 0.5..0.6). Rather
+--          than reverse-engineer the exact bin boundaries (risky - an off-by-
+--          one could silently select the wrong shape), we reuse exact
+--          normalized values ALREADY CONFIRMED by direct sampling to select
+--          each shape we care about: 0.000=Bell, 0.100=LowShelf,
+--          0.325=HighShelf. ezbeq's filter model only ever produces
+--          PeakingEQ/LowShelf/HighShelf (confirmed from ezbeq/iir.py source -
+--          there is no HighPass/LowPass/Notch in its model), so we don't need
+--          known-good points for the other 7 Pro-Q shapes.
+--   output level (used for mv_adjust): PARTIALLY VERIFIED - linear from
+--          norm=0.2 (-21.6dB) to norm=1.0 (+36dB) via formula
+--          db = (norm - 0.5) * 72, confirmed against every sampled point in
+--          that range. Below norm=0.2 (< -21.6dB) the real curve bends toward
+--          -INF and was NOT fully characterized (only a few sample points
+--          exist there and they don't fit a simple formula) - values below
+--          -21.6dB are CLAMPED with a console warning rather than guessed at,
+--          since this directly controls gain-staging/clipping headroom and a
+--          wrong guess here has real audio-safety consequences.
+--
+-- ==============================================================================
+-- BAND ACTIVATION - TWO SEPARATE FLAGS REQUIRED
+-- ==============================================================================
+-- Pro-Q 4 distinguishes "Used" (this band slot exists / is instantiated in
+-- the active chain - shows "Unused" by default even on a freshly loaded
+-- instance) from "Enabled" (this existing band is not bypassed). BOTH must be
+-- set to 1 for a band to actually process audio - confirmed directly from
+-- proq4_dump.lua's raw parameter dump, which showed all 24 bands defaulting
+-- to Used=0 ("Unused") even though Enabled=1. Setting only Enabled=1 (the
+-- more "obvious" flag) silently does nothing audible.
+--
+-- ==============================================================================
+-- DESIGN NOTES
+-- ==============================================================================
+-- - 24 bands in a SINGLE Pro-Q instance is enough capacity for every BEQ
+--   profile seen so far (max observed: 7 filters) - unlike the earlier ReEQ
+--   approach which needed 3 stacked instances (5 bands each) to reach 15.
+-- - mv_adjust (ezbeq's "MV" master-volume-style headroom adjustment, e.g. a
+--   Skyfall-style -3.5dB global trim to prevent clipping from boosted bass
+--   bands) is applied ONCE to Pro-Q's dedicated "Output Level" parameter -
+--   NOT added into each band's individual Gain. An earlier version of
+--   reaper.py had this bug (adding mv_adjust per-band); fixed.
+-- - mv_adjust's real source is entry.mv_adjust on the CatalogueEntry itself
+--   (parsed from the BEQ catalog's "mv" key) - NOT the mv_adjust function
+--   parameter ezbeq's own dispatcher passes around, which is always 0.0 in
+--   practice (confirmed: DeviceRepository.load_filter() in ezbeq/device.py
+--   never actually passes a real value into it). reaper.py reads
+--   entry.mv_adjust directly to work around this.
+-- ==============================================================================
+
+local EXTSTATE_SECTION = "beqbridge"
+local EXTSTATE_KEY = "filters"
+local TRACK_NAME = "BEQ"      -- must exactly match the track name reaper.py/ezbeq targets
+local POLL_INTERVAL = 0.25    -- seconds between ExtState checks - keep well under human-perceptible latency
+local NUM_BANDS = 24          -- Pro-Q 4's maximum band count
+
+-- Which Pro-Q instance on TRACK_NAME to control, counting in FX chain order
+-- (1 = first Pro-Q found scanning top to bottom, 2 = second, etc). Only
+-- relevant if you deliberately load more than one Pro-Q instance on the
+-- track (e.g. one for BEQ, one for something else) - lets you pick which one
+-- ezbeq drives instead of it always grabbing whichever comes first.
+local Proq_Instance = 1
+
+-- When true:
+--   [1] prints each incoming filter's RAW parsed values exactly as received
+--       from the ExtState payload, before any conversion - lets you confirm
+--       ezbeq/reaper.py sent what you expected before blaming the Lua math.
+--   [2] prints the received mv_adjust value the same way.
+--   [3] after applying, reads back every band's ACTUAL current state
+--       directly from Pro-Q via TrackFX_GetFormattedParamValue (real display
+--       strings like "80.0 Hz", "+5.00 dB" - not just the normalized floats
+--       we wrote) - this is a genuine independent confirmation that the
+--       write landed correctly, not just an echo of what we intended to
+--       write. This is what caught the Used-vs-Enabled bug during
+--       development: freq/gain/q could read back correctly while the band
+--       was still silently inactive.
+-- Set to false once you're confident the setup is stable, to reduce console
+-- noise - but there is no real performance cost to leaving it on, since the
+-- console output is small (24 short lines) and poll interval is only 4Hz.
+local DEBUGGING = true
+
+local MIN_FREQ, MAX_FREQ = 10, 30000
+local MIN_Q, MAX_Q = 0.025, 40
+local MIN_GAIN, MAX_GAIN = -30, 30
+
+-- Known-good normalized values, confirmed via proq4_curve_sample.lua, that
+-- reliably produce each Shape we need. See the big comment block at the top
+-- of this file for why this is a lookup table and not a formula.
+local SHAPE_MAP = { PeakingEQ = 0.000, LowShelf = 0.100, HighShelf = 0.325 }
+local SHAPE_DEFAULT = 0.000  -- Bell - safe fallback for any filter type ezbeq might send that we don't recognize
+
+local last_version = -1
+
+-- track/fx/output_level_idx/band_params are populated by init() and
+-- potentially re-populated later if REAPER invalidates our track pointer
+-- (e.g. the project is closed and reopened, or the track is deleted and an
+-- identically-named one recreated) - see the ValidatePtr check in loop().
+local track, fx, output_level_idx
+local band_params = {}  -- [bandnum] = { freq=paramidx, gain=paramidx, q=paramidx, shape=paramidx, used=paramidx, enabled=paramidx }
+
+-- ==============================================================================
+-- CONVERSION HELPERS
+-- ==============================================================================
+
+local function clamp(v, lo, hi)
+  if v < lo then return lo elseif v > hi then return hi else return v end
+end
+
+-- Converts a real frequency in Hz to Pro-Q's normalized 0..1 parameter value.
+-- See the verified-formula comment block at the top of this file.
+local function freq_to_norm(freq)
+  freq = clamp(freq, MIN_FREQ, MAX_FREQ)
+  return clamp(math.log(freq / MIN_FREQ) / math.log(MAX_FREQ / MIN_FREQ), 0, 1)
+end
+
+-- Converts a real Q factor to Pro-Q's normalized 0..1 parameter value.
+local function q_to_norm(q)
+  q = clamp(q, MIN_Q, MAX_Q)
+  return clamp(math.log(q / MIN_Q) / math.log(MAX_Q / MIN_Q), 0, 1)
+end
+
+-- Converts a real gain in dB to Pro-Q's per-BAND normalized 0..1 parameter
+-- value. NOTE: this is a DIFFERENT curve than output_gain_to_norm() below -
+-- band Gain is fully linear across its whole +/-30dB range, but Output Level
+-- (used for mv_adjust) is only linear in part of its range. Do not conflate
+-- the two even though they're both "gain in dB" conceptually.
+local function gain_to_norm(gain)
+  gain = clamp(gain, MIN_GAIN, MAX_GAIN)
+  return clamp((gain - MIN_GAIN) / (MAX_GAIN - MIN_GAIN), 0, 1)
+end
+
+-- Converts a real gain in dB to Pro-Q's Output Level normalized 0..1
+-- parameter value - used exclusively for mv_adjust (ezbeq's master-volume-
+-- style headroom trim), applied ONCE per update, not per band.
+-- See the big verified-formula comment block at the top of this file for why
+-- the valid range is asymmetric (-21.6dB verified floor, not -30dB).
+local OUTPUT_VERIFIED_MIN_DB = -21.6
+local OUTPUT_MAX_DB = 36
+local function output_gain_to_norm(db)
+  if db < OUTPUT_VERIFIED_MIN_DB then
+    if DEBUGGING then
+      reaper.ShowConsoleMsg(string.format(
+        "WARNING: mv_adjust=%.2fdB is below the verified linear range of Output Level (floor %.1fdB) - " ..
+        "clamping to %.1fdB. Run proq4_curve_sample.lua again with more low-end samples if this recurs " ..
+        "often, so the curve can be characterized further down instead of just clamped.\n",
+        db, OUTPUT_VERIFIED_MIN_DB, OUTPUT_VERIFIED_MIN_DB))
+    end
+    db = OUTPUT_VERIFIED_MIN_DB
+  end
+  db = clamp(db, OUTPUT_VERIFIED_MIN_DB, OUTPUT_MAX_DB)
+  return clamp(0.5 + db / 72, 0, 1)
+end
+
+-- ==============================================================================
+-- DISCOVERY HELPERS
+-- ==============================================================================
+
+local function find_track_by_name(name)
+  for i = 0, reaper.CountTracks(0) - 1 do
+    local tr = reaper.GetTrack(0, i)
+    local _, tname = reaper.GetTrackName(tr)
+    if tname == name then return tr end
+  end
+  return nil
+end
+
+local function find_proq(tr, instance_num)
+  local count = reaper.TrackFX_GetCount(tr)
+  local found = 0
+  for i = 0, count - 1 do
+    local _, fx_name = reaper.TrackFX_GetFXName(tr, i, "")
+    if fx_name:find("Pro%-Q") or fx_name:find("FabFilter") then
+      found = found + 1
+      if found == instance_num then
+        return i, found
+      end
+    end
+  end
+  return nil, found
+end
+
+local function build_band_params(tr, fxi)
+  local bands = {}
+  local param_count = reaper.TrackFX_GetNumParams(tr, fxi)
+  for p = 0, param_count - 1 do
+    local _, name = reaper.TrackFX_GetParamName(tr, fxi, p, "")
+    if name == "Output Level" then
+      output_level_idx = p
+    else
+      local bandnum, field = name:match("^Band (%d+) (%a+)$")
+      if bandnum then
+        bandnum = tonumber(bandnum)
+        bands[bandnum] = bands[bandnum] or {}
+        if field == "Frequency" then bands[bandnum].freq = p
+        elseif field == "Gain" then bands[bandnum].gain = p
+        elseif field == "Q" then bands[bandnum].q = p
+        elseif field == "Shape" then bands[bandnum].shape = p
+        elseif field == "Used" then bands[bandnum].used = p
+        elseif field == "Enabled" then bands[bandnum].enabled = p
+        end
+      end
+    end
+  end
+  return bands
+end
+
+local function init()
+  track = find_track_by_name(TRACK_NAME)
+  if not track then
+    reaper.ShowConsoleMsg("Track '" .. TRACK_NAME .. "' not found.\n")
+    return false
+  end
+
+  local total_found
+  fx, total_found = find_proq(track, Proq_Instance)
+  if not fx then
+    reaper.ShowConsoleMsg(string.format(
+      "Proq_Instance=%d requested but only %d Pro-Q instance(s) found on track '%s'.\n",
+      Proq_Instance, total_found, TRACK_NAME))
+    return false
+  end
+
+  band_params = build_band_params(track, fx)
+  reaper.ShowConsoleMsg(string.format(
+    "proq4_apply_filters: initialized (Proq_Instance=%d, FX index %d, %d bands discovered), watching ExtState %s/%s\n",
+    Proq_Instance, fx, NUM_BANDS, EXTSTATE_SECTION, EXTSTATE_KEY))
+  return true
+end
+
+-- ==============================================================================
+-- CORE APPLY / CLEAR LOGIC
+-- ==============================================================================
+
+local function clear_all_bands()
+  for bandnum, p in pairs(band_params) do
+    if p.used then reaper.TrackFX_SetParam(track, fx, p.used, 0) end
+    if p.enabled then reaper.TrackFX_SetParam(track, fx, p.enabled, 0) end
+    if p.gain then reaper.TrackFX_SetParam(track, fx, p.gain, gain_to_norm(0)) end
+  end
+  if output_level_idx then
+    reaper.TrackFX_SetParam(track, fx, output_level_idx, output_gain_to_norm(0))
+  end
+end
+
+local function dump_all_bands()
+  reaper.ShowConsoleMsg("[DEBUG] --- Reading back all 24 bands from Pro-Q ---\n")
+  for bandnum = 1, NUM_BANDS do
+    local p = band_params[bandnum]
+    if p then
+      local function fmt(paramidx)
+        if not paramidx then return "?" end
+        local _, display = reaper.TrackFX_GetFormattedParamValue(track, fx, paramidx, "")
+        return display or "?"
+      end
+      reaper.ShowConsoleMsg(string.format(
+        "[DEBUG] Band %2d: Used=%s Enabled=%s Shape=%s Freq=%s Gain=%s Q=%s\n",
+        bandnum, fmt(p.used), fmt(p.enabled), fmt(p.shape), fmt(p.freq), fmt(p.gain), fmt(p.q)))
+    else
+      reaper.ShowConsoleMsg(string.format("[DEBUG] Band %2d: not discovered (unexpected - Pro-Q should always expose 24 bands)\n", bandnum))
+    end
+  end
+  if output_level_idx then
+    local _, display = reaper.TrackFX_GetFormattedParamValue(track, fx, output_level_idx, "")
+    reaper.ShowConsoleMsg(string.format("[DEBUG] Output Level: %s\n", display or "?"))
+  end
+  reaper.ShowConsoleMsg("[DEBUG] --- End readback ---\n")
+end
+
+local function apply_filters(mv_adjust, filters)
+  clear_all_bands()
+
+  if DEBUGGING then
+    reaper.ShowConsoleMsg(string.format("[DEBUG] Received mv_adjust=%s\n", tostring(mv_adjust)))
+  end
+
+  if output_level_idx and mv_adjust ~= 0 then
+    reaper.TrackFX_SetParam(track, fx, output_level_idx, output_gain_to_norm(mv_adjust))
+  end
+
+  local max_idx = 0
+  for i in pairs(filters) do
+    if i > max_idx then max_idx = i end
+  end
+
+  if max_idx > NUM_BANDS then
+    reaper.ShowConsoleMsg(string.format(
+      "WARNING: %d filters received but only %d bands available on Pro-Q - filters %d+ will be dropped. " ..
+      "Consider whether this BEQ profile genuinely needs more than 24 bands, or whether something " ..
+      "upstream is sending malformed/duplicate data.\n",
+      max_idx, NUM_BANDS, NUM_BANDS + 1))
+  end
+
+  for i = 1, math.min(max_idx, NUM_BANDS) do
+    local f = filters[i]
+    if f then
+      if DEBUGGING then
+        reaper.ShowConsoleMsg(string.format(
+          "[DEBUG] Received filter %d: type=%s freq=%s gain=%s q=%s\n",
+          i, tostring(f.type), tostring(f.freq), tostring(f.gain), tostring(f.q)))
+      end
+
+      local p = band_params[i]
+      if p and p.freq and p.gain and p.q and p.shape and p.used and p.enabled then
+        local shape_norm = SHAPE_MAP[f.type]
+        if not shape_norm then
+          reaper.ShowConsoleMsg(string.format(
+            "Filter %d: unrecognized type '%s', defaulting to Bell (parametric peak).\n", i, f.type))
+          shape_norm = SHAPE_DEFAULT
+        end
+        reaper.TrackFX_SetParam(track, fx, p.shape, shape_norm)
+        reaper.TrackFX_SetParam(track, fx, p.freq, freq_to_norm(f.freq))
+        reaper.TrackFX_SetParam(track, fx, p.gain, gain_to_norm(f.gain))
+        reaper.TrackFX_SetParam(track, fx, p.q, q_to_norm(f.q))
+        reaper.TrackFX_SetParam(track, fx, p.used, 1)
+        reaper.TrackFX_SetParam(track, fx, p.enabled, 1)
+      else
+        reaper.ShowConsoleMsg(string.format(
+          "Filter %d: band %d parameters not fully discovered on this Pro-Q instance - skipped. " ..
+          "This should not normally happen on a standard 24-band Pro-Q 4 instance; if it does, " ..
+          "re-run proq4_dump.lua and check the parameter names actually match \"Band N <Field>\".\n", i, i))
+      end
+    end
+  end
+
+  if DEBUGGING then
+    dump_all_bands()
+  end
+end
+
+-- ==============================================================================
+-- PAYLOAD PARSING
+-- ==============================================================================
+
+local function parse_filters(content)
+  local version = tonumber(content:match("version=(%d+)"))
+  if not version then
+    if DEBUGGING then
+      reaper.ShowConsoleMsg("[DEBUG] parse_filters: no 'version=' found in ExtState content, ignoring - " ..
+        "this is expected if ExtState is empty/stale, but check reaper.py's payload format if it recurs.\n")
+    end
+    return nil
+  end
+
+  if content:match("clear=1") then
+    return { version = version, clear = true, mv = 0, filters = {} }
+  end
+
+  local mv = tonumber(content:match("mv=([%-%d%.]+)")) or 0
+
+  local filters = {}
+  for line in content:gmatch("[^\r\n]+") do
+    local idx, ftype, freq, gain, q = line:match(
+      "band(%d+)%s+type=(%a+)%s+freq=([%-%d%.]+)%s+gain=([%-%d%.]+)%s+q=([%-%d%.]+)"
+    )
+    if idx then
+      filters[tonumber(idx)] = {
+        type = ftype,
+        freq = tonumber(freq),
+        gain = tonumber(gain),
+        q = tonumber(q),
+      }
+    end
+  end
+  return { version = version, clear = false, mv = mv, filters = filters }
+end
+
+-- ==============================================================================
+-- MAIN POLLING LOOP
+-- ==============================================================================
+
+local last_check = 0
+
+local function poll_once()
+  local now = reaper.time_precise()
+  if now - last_check < POLL_INTERVAL then
+    return
+  end
+  last_check = now
+
+  if not reaper.ValidatePtr(track, "MediaTrack*") then
+    if DEBUGGING then
+      reaper.ShowConsoleMsg("[DEBUG] Track pointer no longer valid (project reload / track recreated?) - re-initializing.\n")
+    end
+    if not init() then
+      return
+    end
+  end
+
+  if not reaper.HasExtState(EXTSTATE_SECTION, EXTSTATE_KEY) then
+    return
+  end
+
+  local content = reaper.GetExtState(EXTSTATE_SECTION, EXTSTATE_KEY)
+  local data = parse_filters(content)
+  if not data or data.version == last_version then
+    return
+  end
+  last_version = data.version
+
+  if data.clear then
+    reaper.Undo_BeginBlock()
+    clear_all_bands()
+    reaper.Undo_EndBlock("ezbeq/Pro-Q: clear all bands", -1)
+    reaper.ShowConsoleMsg(string.format("Cleared all bands (version %d)\n", data.version))
+  else
+    reaper.Undo_BeginBlock()
+    apply_filters(data.mv, data.filters)
+    reaper.Undo_EndBlock("ezbeq/Pro-Q: apply filter set", -1)
+    reaper.ShowConsoleMsg(string.format("Applied filter version %d (mv_adjust=%.2f dB)\n", data.version, data.mv))
+  end
+end
+
+local function loop()
+  local ok, err = pcall(poll_once)
+  if not ok then
+    reaper.ShowConsoleMsg("[ERROR] proq4_apply_filters: unexpected error in poll_once(), continuing anyway: "
+      .. tostring(err) .. "\n")
+  end
+  reaper.defer(loop)
+end
+
+if init() then
+  reaper.defer(loop)
+end

--- a/docs/reaper.md
+++ b/docs/reaper.md
@@ -1,0 +1,237 @@
+# Adding a REAPER + FabFilter Pro-Q 4 Device to ezbeq
+
+This guide adds a new `reaper` device type to ezbeq, so it can push BEQ
+filters directly into a FabFilter Pro-Q 4 instance running inside REAPER,
+using REAPER's built-in Web Control interface. No NixOS required - this
+works on any machine that can run Python (Linux, macOS, Windows) for the
+ezbeq side, and any Windows/Mac machine running REAPER on the other end.
+
+The REAPER-side script referenced throughout this guide,
+[`proq4_apply_filters.lua`](proq4_apply_filters.lua), lives alongside this
+page and can be downloaded directly from there. An example ezbeq config is
+also provided at
+[`examples/ezbeq_reaper.yml`](https://github.com/3ll3d00d/ezbeq/blob/master/examples/ezbeq_reaper.yml)
+in the repository root.
+
+## What you need
+
+- ezbeq source code (clone from https://github.com/3ll3d00d/ezbeq)
+- `reaper.py` (the new device module)
+- `proq4_apply_filters.lua` (the REAPER-side script)
+- REAPER, with FabFilter Pro-Q 4 installed
+- Both machines reachable over the network (can be the same machine)
+
+---
+
+## Step 1: Add `reaper.py` to the ezbeq source
+
+Copy `reaper.py` into ezbeq's package folder, alongside the other device
+modules:
+
+```
+ezbeq/ezbeq/reaper.py
+```
+
+(i.e. next to `ezbeq/ezbeq/htp1.py`, `ezbeq/ezbeq/minidsp.py`, etc - same
+folder, same level.)
+
+## Step 2: Modify `device.py` to register the new device type
+
+Open `ezbeq/ezbeq/device.py` and find the `create_devices` function. It
+contains a chain of `elif d_type == '...':` blocks, one per supported
+device type - something like:
+
+```python
+elif d_type == 'camilladsp':
+    from ezbeq.camilladsp import CamillaDsp
+    devices.append(CamillaDsp(name, cfg.config_path, values, ws_server, catalogue))
+```
+
+Add a new `elif` block for `reaper` immediately after it (order among the
+`elif` blocks doesn't matter, but keeping it near the end is tidy):
+
+```python
+elif d_type == 'reaper':
+    from ezbeq.reaper import Reaper
+    devices.append(Reaper(name, cfg.config_path, values, ws_server, catalogue))
+```
+
+Save the file. That's the only source change needed - `reaper.py` itself
+doesn't require any other file to be touched.
+
+## Step 3: Reinstall/rebuild ezbeq so the change is picked up
+
+If you're running ezbeq from source with `pip install -e .` (editable
+install), no reinstall is needed - just restart ezbeq. If you installed it
+as a regular package, reinstall from your modified source tree, e.g.:
+
+```
+pip install --break-system-packages .
+```
+
+(run from inside the ezbeq source folder)
+
+## Step 4: Configure the device in ezbeq's `config.yml`
+
+Add a `reaper1` entry (name is up to you) under `devices:`:
+
+```yaml
+devices:
+  reaper1:
+    type: reaper
+    ip: 192.168.1.50:8080       # the REAPER machine's IP and Web Control port (see Step 5)
+    extstate_section: beqbridge  # optional, this is the default
+    extstate_key: filters        # optional, this is the default
+    timeout: 3                   # optional, HTTP timeout in seconds
+```
+
+Restart ezbeq after saving. You should see a new "REAPER" device/slot show
+up in ezbeq's web UI.
+
+---
+
+## Step 5: Enable REAPER's Web Control interface
+
+This is what lets ezbeq talk to REAPER over HTTP. On the machine running
+REAPER:
+
+1. Open REAPER's preferences: **Options → Preferences → Control/OSC/Web**.
+2. Click **Add**, and choose **"Web browser interface"** from the list (not
+   a plain "OSC" device - this specific one is what exposes the HTTP
+   interface ezbeq needs).
+3. Set a port (e.g. `8080`) - this must match the port you used in
+   `config.yml`'s `ip:` field (e.g. `192.168.1.50:8080`).
+4. Leave the local IP as `0.0.0.0` or blank, so it listens on all network
+   interfaces rather than only localhost (needed since ezbeq is likely
+   running on a different machine).
+5. Click OK/Apply.
+6. **Allow the port through your firewall** on the REAPER machine. On
+   Windows, PowerShell (run as Administrator):
+   ```powershell
+   New-NetFirewallRule -DisplayName "REAPER Web Control" -Direction Inbound -Protocol TCP -LocalPort 8080 -Action Allow
+   ```
+
+**Test it works** before moving on - from the ezbeq machine (or any
+machine on the network), run:
+
+```
+curl "http://192.168.1.50:8080/_/SET/EXTSTATE/beqbridge/filters/hello"
+```
+
+If REAPER is reachable, this returns without a network error (the actual
+HTTP response body doesn't matter much here - a connection failure is the
+thing to watch for).
+
+## Step 6: Set up the track and Pro-Q 4 instance in REAPER
+
+1. Create a track in your REAPER project (or use an existing one) that sits
+   in your BEQ signal path.
+2. **Name the track** something specific - e.g. `BEQ`. You'll need this
+   exact name in the Lua script (see `TRACK_NAME` below).
+3. Add a single **FabFilter Pro-Q 4** instance to that track's FX chain.
+   One instance gives you 24 bands, which is enough headroom for any BEQ
+   profile likely to be encountered.
+
+## Step 7: Install and run `proq4_apply_filters.lua`
+
+1. Copy `proq4_apply_filters.lua` into REAPER's Scripts folder. You can
+   find/create this folder via **Options → Show REAPER resource path in
+   explorer/finder**, then look for (or create) a `Scripts` subfolder.
+2. In REAPER, open the **Actions List** (`?` menu or `Actions →
+   Show action list...`).
+3. Click **New action... → Load ReaScript...** and select
+   `proq4_apply_filters.lua`.
+4. With the action selected in the list, click **Run** (or double-click
+   it) to start it.
+
+The script runs continuously in the background (via REAPER's `defer()`
+mechanism) until you stop it or close REAPER - it doesn't finish and exit
+like a one-shot script. You'll need to run it again each time you reopen
+the project, unless you set up an auto-start (see note at the end).
+
+Check REAPER's console (the same window ReaScript errors/prints show up
+in) for a line like:
+
+```
+proq4_apply_filters: initialized (Proq_Instance=1, FX index 0, 24 bands discovered), watching ExtState beqbridge/filters
+```
+
+If instead you see `"Track 'BEQ' not found."` or similar, see the
+`TRACK_NAME` section below.
+
+---
+
+## The three variables you'll most likely need to adjust
+
+These are all declared near the top of `proq4_apply_filters.lua` as plain
+Lua `local` variables - edit the file directly and re-run it (stop the
+running instance first, or just re-run it after editing; REAPER doesn't
+require a restart) to apply a change.
+
+### `TRACK_NAME`
+
+```lua
+local TRACK_NAME = "BEQ"
+```
+
+Must **exactly match** (case-sensitive) the name of the track holding your
+Pro-Q 4 instance (Step 6). If you named your track something other than
+`BEQ`, change this to match. If it doesn't match, the script will print
+`Track '<name>' not found.` and won't do anything else.
+
+### `Proq_Instance`
+
+```lua
+local Proq_Instance = 1
+```
+
+Which Pro-Q 4 instance on that track to control, if you have more than
+one loaded (counting from the top of the FX chain: `1` = the first Pro-Q
+found, `2` = the second, etc). Most setups only need one Pro-Q instance on
+the track, so the default of `1` is normally correct. If you ever add a
+second Pro-Q instance for some other purpose and the script grabs the
+wrong one, change this to point at the right one - the console message on
+startup tells you which FX index it actually picked.
+
+### `DEBUGGING`
+
+```lua
+local DEBUGGING = true
+```
+
+When `true`, the script prints extra detail to REAPER's console on every
+filter update:
+- each incoming filter's raw values exactly as received (before any unit
+  conversion),
+- the received `mv_adjust` value,
+- and, after applying, a full readback of all 24 bands' *actual* current
+  state read directly back from Pro-Q (not just what the script thinks it
+  wrote) - useful for confirming a filter load really took effect.
+
+Leave this `true` while you're setting things up and verifying everything
+works. Once you're confident it's stable, you can set it to `false` to
+quiet the console down - there's no real performance cost either way, so
+this is purely about how much console output you want to see.
+
+---
+
+## Testing end to end
+
+1. In ezbeq's web UI, pick a BEQ catalog entry and load it onto the
+   `reaper1` device/slot.
+2. Watch REAPER's console - you should see filter values being received
+   and applied, and (if `DEBUGGING = true`) a full band readback.
+3. Open Pro-Q 4's own GUI on the track and visually confirm the bands moved
+   as expected.
+4. Try clearing the filter from ezbeq's UI and confirm all bands reset to
+   flat/off in Pro-Q.
+
+## Optional: auto-starting the script
+
+By default you have to manually run the script from the Actions List each
+time you open the project. If you want it to start automatically, REAPER
+supports a "global startup action" (via the SWS extension) or a
+project-specific startup action - search REAPER's own documentation/forum
+for "startup action" for the exact current steps for your REAPER version,
+since this is a REAPER-level feature unrelated to anything in this guide's
+scripts themselves.

--- a/examples/ezbeq_reaper.yml
+++ b/examples/ezbeq_reaper.yml
@@ -1,0 +1,10 @@
+accessLogging: false
+debugLogging: true
+devices:
+  reaper1:
+    type: reaper
+    ip: 192.168.1.50:8080
+    extstate_section: beqbridge
+    extstate_key: filters
+    timeout: 3
+port: 8080

--- a/ezbeq/device.py
+++ b/ezbeq/device.py
@@ -187,6 +187,9 @@ def create_devices(cfg: Config, ws_server: WsServer, catalogue: CatalogueProvide
         elif d_type == 'camilladsp':
             from ezbeq.camilladsp import CamillaDsp
             devices.append(CamillaDsp(name, cfg.config_path, values, ws_server, catalogue))
+        elif d_type == 'reaper':
+            from ezbeq.reaper import Reaper
+            devices.append(Reaper(name, cfg.config_path, values, ws_server, catalogue))
     if not devices:
         raise ValueError('No device configured')
     else:

--- a/ezbeq/reaper.py
+++ b/ezbeq/reaper.py
@@ -1,0 +1,304 @@
+import logging
+import time
+import urllib.parse
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+from ezbeq.apis.ws import WsServer
+from ezbeq.catalogue import CatalogueEntry, CatalogueProvider
+from ezbeq.device import DeviceState, SlotState, PersistentDevice
+
+logger = logging.getLogger('ezbeq.reaper')
+
+# ezbeq's CatalogueEntry.filters carry a 'type' field using these exact
+# literal strings - confirmed directly from source, not assumed:
+#   - ezbeq/iir.py defines exactly three Biquad subclasses: PeakingEQ,
+#     LowShelf, HighShelf.
+#   - ezbeq/minidsp.py's filter-building code does `t = f['type']` and then
+#     branches on `t == 'PeakingEQ'` / `'LowShelf'` / `'HighShelf'` - these
+#     are literally the only three strings ezbeq's own code ever checks for.
+# There is NO HighPass/LowPass/Notch filter type anywhere in ezbeq's model.
+# The actual mapping from these strings to REAPER/Pro-Q-specific band
+# "Shape" values is done entirely on the Lua side (proq4_apply_filters.lua)
+# - this module only forwards the type string through as-is, unmodified, so
+# it stays correct regardless of which REAPER-side EQ plugin/script consumes
+# it (this module has already been repointed from ReaEQ -> ReEQ -> Pro-Q 4
+# over the course of development without needing any changes here, since the
+# type strings themselves never changed).
+KNOWN_FILTER_TYPES = {'PeakingEQ', 'LowShelf', 'HighShelf'}
+
+
+class ReaperSlotState(SlotState):
+
+    def __init__(self):
+        super().__init__('REAPER')
+
+
+class ReaperState(DeviceState):
+
+    def __init__(self, name: str):
+        self.__name = name
+        self.slot = ReaperSlotState()
+        self.slot.active = True
+
+    def serialise(self) -> dict:
+        return {
+            'type': 'reaper',
+            'name': self.__name,
+            'slots': [self.slot.as_dict()]
+        }
+
+
+class Reaper(PersistentDevice[ReaperState]):
+    """
+    Sends BEQ filters to a REAPER instance running FabFilter Pro-Q 4, via
+    REAPER's built-in Web Control interface (Options > Preferences >
+    Control/OSC/Web > "Web browser interface").
+
+    High-level data flow:
+      1. This class builds a small flat-text payload describing the filter
+         set (see __build_payload) and HTTP GETs it to REAPER's Web Control
+         endpoint, which stores it into REAPER's in-process ExtState memory
+         via the SET/EXTSTATE command (see __push_extstate).
+      2. A persistent ReaScript running inside REAPER itself
+         (proq4_apply_filters.lua) polls that ExtState value on a timer,
+         and when it changes, converts the real Hz/dB/Q values in the
+         payload into Pro-Q 4's normalized 0..1 VST3 parameters (using
+         curve formulas reverse-engineered from real REAPER API data - see
+         that script's own extensive comments) and writes them via
+         TrackFX_SetParam.
+
+    Why not REAPER's native EQ scripting API (TrackFX_SetEQParam)? That API
+    is specific to REAPER's own native ReaEQ plugin and does not recognize
+    Pro-Q 4 at all (confirmed empirically - see proq4_dump.lua). Why not
+    ReaEQ itself? It reliably crashed on sub-20Hz frequencies during
+    development, which BEQ profiles can require. Why not the free JSFX
+    "ReEQ" plugin (an earlier iteration of this integration)? It only
+    exposes 5 automatable bands per instance, requiring multiple stacked
+    instances to reach a usable band count; Pro-Q 4 offers 24 bands in a
+    single instance.
+
+    Config (see examples/ezbeq_reaper.yml):
+      devices:
+        reaper1:
+          type: reaper
+          ip: 192.168.1.50:8080         # REAPER machine, Web Control port
+          extstate_section: beqbridge   # optional, defaults shown
+          extstate_key: filters         # optional, defaults shown
+          timeout: 3                    # optional, HTTP timeout in seconds (applies per retry attempt)
+    """
+
+    def __init__(self, name: str, config_path: str, cfg: dict, ws_server: WsServer, catalogue: CatalogueProvider):
+        super().__init__(config_path, name, ws_server)
+        self.__name = name
+        self.__catalogue = catalogue
+        self.__ip = cfg['ip']
+        self.__section = cfg.get('extstate_section', 'beqbridge')
+        self.__key = cfg.get('extstate_key', 'filters')
+        self.__timeout = cfg.get('timeout', 3)
+
+        # A plain requests.get() per call would fail outright on any
+        # transient network hiccup (the NixOS<->Windows link is a real LAN
+        # hop, not localhost, so brief drops/reboots/Wi-Fi blips are a
+        # realistic occurrence over time). A Session with a Retry-backed
+        # HTTPAdapter automatically retries on connection failures and on
+        # the given HTTP status codes, with exponential-ish backoff between
+        # attempts, before finally giving up and raising - meaningfully
+        # more resilient than a one-shot request for a bridge component
+        # that's expected to run unattended for long periods.
+        self.__session = requests.Session()
+        retries = Retry(
+            total=3,                                   # up to 3 retry attempts beyond the initial try
+            backoff_factor=0.1,                         # ~0.1s, 0.2s, 0.4s delays between retries
+            status_forcelist=[500, 502, 503, 504],       # retry on these server-side error codes
+        )
+        self.__session.mount('http://', HTTPAdapter(max_retries=retries))
+
+    def _load_initial_state(self) -> ReaperState:
+        return ReaperState(self.name)
+
+    def _merge_state(self, loaded: ReaperState, cached: dict) -> ReaperState:
+        # Restores the last-known slot title/author from ezbeq's persisted
+        # cache on startup, purely for UI display purposes (so the
+        # dashboard shows what was last loaded even immediately after an
+        # ezbeq restart, before any new filter load happens).
+        if 'slots' in cached:
+            for slot in cached['slots']:
+                if slot.get('id') == 'REAPER':
+                    if slot.get('last'):
+                        loaded.slot.last = slot['last']
+                    if slot.get('author'):
+                        loaded.slot.last_author = slot['author']
+        return loaded
+
+    @property
+    def device_type(self) -> str:
+        return self.__class__.__name__.lower()
+
+    def update(self, params: dict) -> bool:
+        # This is the actual entry point ezbeq's REST API / web UI calls
+        # when a user picks a catalog entry (or clears one) for this device
+        # from the dashboard - NOT load_filter()/clear_filter() directly.
+        any_update = False
+        if 'slots' in params:
+            for slot in params['slots']:
+                if slot['id'] == 'REAPER':
+                    if 'entry' in slot:
+                        if slot['entry']:
+                            match = self.__catalogue.find(slot['entry'])
+                            if match:
+                                self.load_filter('REAPER', match)
+                                any_update = True
+                        else:
+                            self.clear_filter('REAPER')
+                            any_update = True
+        return any_update
+
+    def activate(self, slot: str) -> None:
+        def __do_it():
+            self._current_state.slot.active = True
+
+        self._hydrate_cache_broadcast(__do_it)
+
+    def load_biquads(self, slot: str, overwrite: bool, inputs: list[int], outputs: list[int],
+                     biquads: list[dict]) -> None:
+        raise NotImplementedError()
+
+    def send_commands(self, slot: str, inputs: list[int], outputs: list[int], commands: list[str]) -> None:
+        raise NotImplementedError()
+
+    def load_filter(self, slot: str, entry: CatalogueEntry, mv_adjust: float = 0.0) -> None:
+        # IMPORTANT, non-obvious gotcha: the mv_adjust FUNCTION PARAMETER
+        # here is NOT reliable and should not be trusted. ezbeq's actual
+        # call dispatcher - DeviceRepository.load_filter() in
+        # ezbeq/device.py, which is what the REST API really calls - never
+        # passes a real value into this parameter; it always defaults to
+        # 0.0 regardless of what the catalog entry actually specifies. This
+        # is true for every device type in ezbeq, not just this one (grep
+        # confirms no device anywhere in ezbeq reads entry.mv_adjust
+        # normally, this parameter appears to be effectively vestigial in
+        # the current codebase).
+        #
+        # The REAL mv_adjust value lives on entry.mv_adjust itself - parsed
+        # directly from the BEQ catalog's "mv" key in ezbeq/catalogue.py's
+        # CatalogueEntry.__init__. We read it from there explicitly instead
+        # of trusting the parameter, which is why every method below takes
+        # care to pass entry.mv_adjust (not the mv_adjust parameter) onward.
+        effective_mv_adjust = entry.mv_adjust
+
+        def __do_it():
+            try:
+                self.__send(entry.filters, effective_mv_adjust)
+                self._current_state.slot.last = entry.formatted_title
+                self._current_state.slot.last_author = entry.author
+            except Exception as e:
+                self._current_state.slot.last = 'ERROR'
+                self._current_state.slot.last_author = None
+                raise e
+
+        self._hydrate_cache_broadcast(__do_it)
+
+    def clear_filter(self, slot: str) -> None:
+        def __do_it():
+            try:
+                self.__send_clear()
+                self._current_state.slot.last = 'Empty'
+                self._current_state.slot.last_author = None
+            except Exception as e:
+                self._current_state.slot.last = 'ERROR'
+                self._current_state.slot.last_author = None
+                raise e
+
+        self._hydrate_cache_broadcast(__do_it)
+
+    def mute(self, slot: str | None, channel: int | None) -> None:
+        raise NotImplementedError()
+
+    def unmute(self, slot: str | None, channel: int | None) -> None:
+        raise NotImplementedError()
+
+    def set_gain(self, slot: str | None, channel: int | None, gain: float) -> None:
+        raise NotImplementedError()
+
+    def levels(self) -> dict:
+        return {}
+
+    def __build_payload(self, filters: list[dict], mv_adjust: float = 0.0) -> str:
+        """
+        Builds the flat-text payload consumed by proq4_apply_filters.lua on
+        the REAPER side. Deliberately NOT JSON: REAPER's ReaScript Lua
+        environment doesn't ship a JSON library by default, and this format
+        is trivially parsable with plain Lua string patterns, avoiding an
+        extra dependency on the REAPER/Windows side entirely.
+
+        Format:
+            version=<int, ms since epoch>
+            mv=<float>
+            band1 type=<str> freq=<float> gain=<float> q=<float> enabled=1
+            band2 type=<str> freq=<float> gain=<float> q=<float> enabled=1
+            ...
+        """
+        # Monotonically increasing version derived from wall-clock time in
+        # milliseconds (NOT a simple incrementing counter). This matters
+        # because the Lua side's "has this changed since I last saw it"
+        # comparison is a simple inequality check against the last version
+        # it processed - a plain counter would RESET to 0/1 every time
+        # ezbeq itself restarts, and could then compare as "older" than a
+        # version the Lua script already processed in a previous ezbeq
+        # session, causing a real update to be silently ignored. A
+        # wall-clock-derived value only ever increases, so this failure
+        # mode can't happen even across ezbeq restarts.
+        version = int(time.time() * 1000)
+        lines = [f"version={version}", f"mv={mv_adjust}"]
+        for i, f in enumerate(filters, start=1):
+            ftype = f.get('type', 'PeakingEQ')
+            if ftype not in KNOWN_FILTER_TYPES:
+                # Not fatal - forwarded as-is. The Lua side has its own
+                # fallback (defaults to a parametric "Bell" band) so a
+                # genuinely never-before-seen type string degrades
+                # gracefully instead of breaking the whole filter load.
+                logger.warning(f"Unrecognised filter type '{ftype}' in filter {i}, sending as-is - "
+                                f"the Lua side will default to parametric if it doesn't recognise it either")
+            lines.append(
+                f"band{i} type={ftype} freq={f['freq']} gain={f['gain']} "
+                f"q={f['q']} enabled=1"
+            )
+        return "\n".join(lines)
+
+    def __send(self, filters: list[dict], mv_adjust: float = 0.0):
+        payload = self.__build_payload(filters, mv_adjust)
+        logger.info(f"Sending {len(filters)} filters to REAPER at {self.__ip} (mv_adjust={mv_adjust})")
+        self.__push_extstate(payload)
+
+    def __send_clear(self):
+        # Same version scheme as __build_payload - see comment there.
+        version = int(time.time() * 1000)
+        payload = f"version={version}\nclear=1"
+        logger.info(f"Clearing filters on REAPER at {self.__ip}")
+        self.__push_extstate(payload)
+
+    def __push_extstate(self, payload: str):
+        """
+        Pushes payload into REAPER's ExtState via its Web Control HTTP
+        interface. section/key/value must all be urlencoded per REAPER's
+        own web control documentation - urllib.parse.quote with safe=''
+        ensures even characters like '/' and '=' inside the payload
+        (present in e.g. "freq=80") get escaped, since those would
+        otherwise be misinterpreted as URL path separators by REAPER's
+        request parser.
+
+        Uses self.__session (see __init__) rather than a bare
+        requests.get(), so transient network failures are retried
+        automatically instead of immediately raising - important since
+        this HTTP call crosses a real LAN link (NixOS -> Windows), not
+        localhost, and is expected to run unattended for long periods.
+        """
+        encoded = urllib.parse.quote(payload, safe='')
+        url = (
+            f"http://{self.__ip}/_/"
+            f"SET/EXTSTATE/{self.__section}/{self.__key}/{encoded}"
+        )
+        resp = self.__session.get(url, timeout=self.__timeout)
+        resp.raise_for_status()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,5 +14,6 @@ nav:
   - Home: index.md
   - Raspberry Pi Installation: rpi.md
   - Windows Installation: win.md
+  - REAPER Integration: reaper.md
 extra_javascript:
   - 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,26 @@ def minidsp_client(minidsp_app):
 
 
 @pytest.fixture
+def reaper_app(httpserver: HTTPServer, tmp_path):
+    """
+    Create and configure a new app instance for each test, wired up to
+    talk to the SAME fake httpserver used for catalogue downloads
+    (configure_downloader above) - reaper.py's HTTP calls to REAPER's Web
+    Control interface land on this same fake server, so we can use
+    httpserver.log to inspect exactly what was sent, the same way the
+    real REAPER machine would receive it.
+    """
+    app, ws = main.create_app(ReaperSpyConfig(httpserver.host, httpserver.port, tmp_path))
+    yield app
+
+
+@pytest.fixture
+def reaper_client(reaper_app):
+    """A test client for the app."""
+    return reaper_app.test_client()
+
+
+@pytest.fixture
 def minidsp_ddrc24_app(httpserver: HTTPServer, tmp_path):
     """Create and configure a new app instance for each test."""
     app, ws = main.create_app(MinidspSpyConfig(httpserver.host, httpserver.port, tmp_path, device_type='DDRC24'))
@@ -319,6 +339,52 @@ class MinidspSpyConfig(Config):
 
     def create_minidsp_runner(self, exe: str, options: str):
         return self.spy
+
+    @property
+    def config_path(self):
+        return self.__tmp_path
+
+    @property
+    def version(self):
+        return '1.2.3'
+
+
+class ReaperSpyConfig(Config):
+    """
+    Test double for the Reaper device's config. Unlike MinidspSpyConfig
+    (which fakes the minidsp CLI process) or CamillaDspSpyConfig (which
+    fakes a websocket server), Reaper's device talks plain HTTP - so this
+    just points reaper.py's 'ip' config value at the SAME fake httpserver
+    already used for catalogue downloads, letting tests inspect exactly
+    what reaper.py sent via httpserver.log rather than needing a custom
+    spy/mock object.
+    """
+
+    def __init__(self, host: str, port: int, tmp_path):
+        self.__host = host
+        self.__port = port
+        self.__tmp_path = tmp_path
+        super().__init__('spy', beqcatalogue_url=f"http://{host}:{port}/")
+
+    @property
+    def load_catalogue_at_startup(self):
+        return True
+
+    def load_config(self):
+        return {
+            'debugLogging': False,
+            'accessLogging': False,
+            'port': 8080,
+            'devices': {
+                'reaper1': {
+                    'type': 'reaper',
+                    'ip': f'{self.__host}:{self.__port}',
+                    # short timeout so a test that deliberately doesn't stub
+                    # a response (if any) fails fast rather than hanging
+                    'timeout': 2,
+                }
+            }
+        }
 
     @property
     def config_path(self):

--- a/tests/test_reaper_api.py
+++ b/tests/test_reaper_api.py
@@ -1,0 +1,115 @@
+import re
+import urllib.parse
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+EXTSTATE_URI_PATTERN = re.compile(r"^/_/SET/EXTSTATE/.*")
+
+
+def test_load_known_entry_via_filter_endpoint_and_then_clear(reaper_client, reaper_app, httpserver: HTTPServer):
+    """
+    Exercises the v1 PUT/DELETE .../filter/<slot> endpoint, which calls
+    Reaper.load_filter()/clear_filter() directly (NOT via update()). This
+    is the path that matters most for the mv_adjust fix, since
+    load_filter() is where entry.mv_adjust is read directly rather than
+    trusting the (unreliable) mv_adjust function parameter.
+    """
+    httpserver.expect_request(EXTSTATE_URI_PATTERN).respond_with_data("ok", content_type="text/plain")
+
+    r = reaper_client.put(
+        "/api/1/devices/reaper1/filter/REAPER",
+        json={"entryId": "123456_0"},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["type"] == "reaper"
+    assert body["slots"][0]["id"] == "REAPER"
+    assert body["slots"][0]["last"] == "Alien Resurrection"
+
+    payload = _last_extstate_payload(httpserver)
+    assert "version=" in payload
+    # Alien Resurrection's test catalogue entry has mv: "+3" - confirms
+    # entry.mv_adjust (not the load_filter() mv_adjust parameter, which
+    # ezbeq's real dispatcher never populates) is what actually gets sent.
+    assert "mv=3.0" in payload
+
+    # 5 identical LowShelf filters per the test catalogue fixture
+    for i in range(1, 6):
+        assert f"band{i} type=LowShelf freq=33.0 gain=5.0 q=0.9 enabled=1" in payload
+    assert "band6" not in payload
+
+    httpserver.clear_all_handlers()
+    httpserver.expect_request(EXTSTATE_URI_PATTERN).respond_with_data("ok", content_type="text/plain")
+
+    r = reaper_client.delete("/api/1/devices/reaper1/filter/REAPER")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["slots"][0]["last"] == "Empty"
+
+    clear_payload = _last_extstate_payload(httpserver)
+    assert "clear=1" in clear_payload
+
+
+def test_load_known_entry_via_slots_endpoint(reaper_client, reaper_app, httpserver: HTTPServer):
+    """
+    Exercises the v2 PATCH .../devices/<name> endpoint, which calls
+    Reaper.update() -> load_filter() - a different code path than the v1
+    test above, but should behave identically since update() delegates
+    straight to the same method.
+
+    NOTE: clearing via this endpoint with {"entry": null} is NOT valid
+    usage - ezbeq's own v2 request schema (flask-restx model validation)
+    rejects null for the 'entry' field outright with a 400
+    ("None is not of type 'string'"), confirmed empirically. Clearing is
+    only covered here via the v1 DELETE .../filter/<slot> endpoint (see
+    the test above), which is the correct way to clear a slot.
+    """
+    httpserver.expect_request(EXTSTATE_URI_PATTERN).respond_with_data("ok", content_type="text/plain")
+
+    r = reaper_client.patch(
+        "/api/2/devices/reaper1",
+        json={"slots": [{"id": "REAPER", "entry": "123456_0"}]},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["slots"][0]["last"] == "Alien Resurrection"
+
+    payload = _last_extstate_payload(httpserver)
+    assert "mv=3.0" in payload
+    assert "band1 type=LowShelf freq=33.0 gain=5.0 q=0.9 enabled=1" in payload
+
+
+def test_unknown_entry_returns_404(reaper_client):
+    """
+    No filters should be sent to REAPER at all for an entry id that isn't
+    in the catalogue - the request should fail fast with a 404 rather than
+    forwarding garbage.
+    """
+    r = reaper_client.put(
+        "/api/1/devices/reaper1/filter/REAPER",
+        json={"entryId": "does-not-exist"},
+    )
+    assert r.status_code == 404
+
+
+def _last_extstate_payload(httpserver: HTTPServer) -> str:
+    """
+    Pulls the most recent request matching our SET/EXTSTATE handler out of
+    httpserver.log and url-decodes the payload REAPER (in real life) would
+    have received - httpserver.log is pytest_httpserver's built-in record
+    of every request/response pair, which serves the same purpose here as
+    the custom Spy objects used for the minidsp/camilladsp devices, since
+    Reaper's device makes plain HTTP calls with no CLI/websocket layer to
+    intercept instead.
+    """
+    matching = [
+        req for req, _ in httpserver.log
+        if req.path.startswith("/_/SET/EXTSTATE/")
+    ]
+    assert matching, "no SET/EXTSTATE request was received by the fake REAPER server"
+    last_request = matching[-1]
+    # The payload is the final path segment, url-encoded by reaper.py's
+    # urllib.parse.quote(payload, safe='') - decode it back to plain text.
+    encoded_payload = last_request.path.split("/")[-1]
+    return urllib.parse.unquote(encoded_payload)


### PR DESCRIPTION
## Summary

Adds a new `reaper` device type to ezbeq, letting it push BEQ filters
directly into a FabFilter Pro-Q 4 instance running inside REAPER. This
follows the existing `Htp1`/`CamillaDsp` device pattern - no changes to
ezbeq's core dispatch logic beyond registering the new type.

## Motivation

REAPER + Pro-Q 4 is an unique setup for home-theater/audio enthusiasts who
want a fully software-defined signal chain, and there wasn't previously a
way to drive REAPER's EQ automatically from ezbeq's catalog. This closes
that gap without requiring any REAPER-side plugin/extension beyond what
ships in REAPER itself (Web Control) plus a standard commercial EQ plugin
that many REAPER users doing serious EQ work already own.

## How it works

- ezbeq builds a small flat-text payload (not JSON - REAPER's ReaScript
  Lua environment doesn't ship a JSON library by default) describing the
  filter set, and pushes it via HTTP GET to REAPER's built-in Web Control
  interface (`Options > Preferences > Control/OSC/Web > "Web browser
  interface"`), using the `SET/EXTSTATE` command to store it in REAPER's
  in-process ExtState memory.
- A companion ReaScript running inside REAPER (`proq4_apply_filters.lua`,
  **not** part of this PR - it's Lua, not Python, and runs inside REAPER
  rather than being installed via pip) polls that ExtState value and, when
  it changes, converts the filters into Pro-Q 4's normalized VST3
  parameters and applies them via `TrackFX_SetParam`.
- The full REAPER-side setup (enabling Web Control, installing the
  ReaScript, track/plugin setup) is documented in `docs/reaper.md`,
  included in this PR.

## Why not REAPER's native EQ scripting API?

`TrackFX_GetEQParam`/`TrackFX_SetEQParam` are specific to REAPER's own
native ReaEQ plugin and don't recognize third-party VST3 plugins like
Pro-Q 4 (confirmed empirically during development - see the setup guide
for the diagnostic approach used). Pro-Q 4's automatable parameters are
generic normalized 0..1 VST3 floats; the conversion curves used in the
companion Lua script were reverse-engineered from real
`TrackFX_FormatParamValueNormalized()` sample data, not guessed at, since
Pro-Q is closed-source.

## A note on `mv_adjust`

While building this, I noticed `entry.mv_adjust` (the BEQ catalog's
master-volume-style headroom adjustment, parsed from the catalog's `"mv"`
key in `catalogue.py`) doesn't appear to be consumed by any existing
device in the codebase, and `DeviceRepository.load_filter()` in
`device.py` never actually passes a real value into the `mv_adjust`
parameter on any device's `load_filter()` method - it's always `0.0`
regardless of what the catalog entry specifies. This device works around
that by reading `entry.mv_adjust` directly rather than trusting the
parameter. I don't know if this is a known/intentional gap or worth
addressing more broadly across other devices.

## Testing

- Full existing test suite passes unmodified (740 tests), plus 3 new
  tests added specifically for this device (743 total).
- New `tests/test_reaper_api.py` covers both entry points that can
  trigger a filter load (the v1 PUT/DELETE `.../filter/<slot>` endpoint,
  which calls `load_filter()`/`clear_filter()` directly, and the v2
  PATCH `.../devices/<name>` endpoint, which goes through `update()`),
  using `pytest_httpserver`'s built-in request log to inspect exactly
  what got sent - simpler than the custom Spy objects used for the
  minidsp/camilladsp devices, since this device makes plain HTTP calls
  with no CLI/websocket layer to intercept.
- One of the new tests is specifically a regression test for the
  `mv_adjust` bug mentioned below - it asserts `entry.mv_adjust` (not the
  `load_filter()` parameter) ends up in the outgoing payload, using the
  existing test catalogue's "Alien Resurrection" entry (which has
  `mv: "+3"`).
- Manually tested end-to-end against a real REAPER 7 + Pro-Q 4 setup,
  including verifying filter values land correctly by reading them back
  from the plugin (not just trusting the write calls succeeded), and a
  real-world BEQ profile (Skyfall) including its `mv` adjustment.

## Files changed

- `ezbeq/reaper.py` (new) - the device implementation
- `ezbeq/device.py` (one new `elif` branch in `create_devices()`)
- `tests/test_reaper_api.py` (new)
- `tests/conftest.py` (adds `ReaperSpyConfig` + `reaper_app`/`reaper_client` fixtures, following the existing `MinidspSpyConfig` pattern)
- `docs/reaper.md` (new) - full setup guide, registered in `mkdocs.yml`'s nav
- `docs/proq4_apply_filters.lua` (new) - the REAPER-side ReaScript this device requires to actually do anything. This isn't part of ezbeq's Python codebase (it runs inside REAPER, not via pip), and there's no existing convention in this repo for a non-Python companion script - I placed it alongside the doc that explains it so it's downloadable directly from the published docs site. Happy to relocate if you'd prefer a different layout (e.g. a top-level `reascripts/` folder) - this was my best guess at fitting your conventions, not a strong opinion.
- `examples/ezbeq_reaper.yml` (new) - follows the existing `examples/ezbeq_<devicetype>.yml` pattern. This was already referenced by `reaper.py`'s own docstring but didn't actually exist until this PR.
- `mkdocs.yml` (one new nav entry for `docs/reaper.md`)

## A note on file placement

`docs/proq4_apply_filters.lua` and `docs/reaper.md` are the two pieces
that live outside ezbeq's own Python execution model - the Lua script
specifically runs inside REAPER itself, not as part of ezbeq. I placed
them following your existing `docs/` conventions as best I could infer
them, but if you'd rather keep non-Python companion scripts out of the
main repo entirely (e.g. a separate gist/repo), I'm happy to adjust -
just let me know.
