### PR TITLE
ci: skip CI checks for pure version-bump commits

### DIFF
--- a/.github/workflows/detect-version-bump.yaml
+++ b/.github/workflows/detect-version-bump.yaml
@@ -1,0 +1,51 @@
+name: Detect version-only bump
+on:
+  workflow_call:
+    outputs:
+      skip:
+        description: "'true' if this push is a single commit that only bumps the version in pyproject.toml/uv.lock"
+        value: ${{ jobs.check.outputs.skip }}
+jobs:
+  check:
+    name: Check for pure version bump
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+      - id: check
+        # Only skip CI when ALL of the following hold, so a "bump version" commit
+        # message can never be used to smuggle in unrelated changes:
+        #  - the push is exactly one commit
+        #  - that commit's message is exactly "bump version"
+        #  - the commit touches only pyproject.toml and/or uv.lock
+        #  - every changed line in those files is a `version = "X.Y.Z"` line
+        run: |
+          skip=false
+          commit_count=$(echo '${{ toJson(github.event.commits) }}' | jq 'length')
+          msg=$(git log -1 --format=%B HEAD | sed -e 's/[[:space:]]*$//')
+          if [[ "$commit_count" == "1" ]] && [[ "$msg" =~ ^[Bb]ump[[:space:]]version$ ]] && git rev-parse HEAD~1 >/dev/null 2>&1; then
+            files=$(git diff --name-only HEAD~1 HEAD)
+            is_pure=true
+            while IFS= read -r f; do
+              [[ -z "$f" ]] && continue
+              if [[ "$f" != "pyproject.toml" && "$f" != "uv.lock" ]]; then
+                is_pure=false
+              fi
+            done <<< "$files"
+            if [[ "$is_pure" == "true" && -n "$files" ]]; then
+              bad=$(git diff -U0 HEAD~1 HEAD -- pyproject.toml uv.lock \
+                | grep -E '^[+-]' \
+                | grep -vE '^(\+\+\+|---)' \
+                | grep -vE '^[+-]version = "[0-9]+\.[0-9]+\.[0-9]+"$' \
+                || true)
+              if [[ -z "$bad" ]]; then
+                skip=true
+              fi
+            fi
+          fi
+          echo "Version-only bump detected: $skip"
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/detect-version-bump.yaml
+++ b/.github/workflows/detect-version-bump.yaml
@@ -30,10 +30,13 @@ jobs:
         # expression. That would skip build/test on every pull_request run, not
         # just version-bump pushes. This job must always complete successfully;
         # the push-only logic lives entirely inside this step instead.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMITS_JSON: ${{ toJson(github.event.commits) }}
         run: |
           skip=false
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            commit_count=$(echo '${{ toJson(github.event.commits) }}' | jq 'if type=="array" then length else 0 end')
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            commit_count=$(echo "$COMMITS_JSON" | jq 'if type=="array" then length else 0 end')
             msg=$(git log -1 --format=%B HEAD | sed -e 's/[[:space:]]*$//')
             if [[ "$commit_count" == "1" ]] && [[ "$msg" =~ ^[Bb]ump[[:space:]]version$ ]] && git rev-parse HEAD~1 >/dev/null 2>&1; then
               files=$(git diff --name-only HEAD~1 HEAD)

--- a/.github/workflows/detect-version-bump.yaml
+++ b/.github/workflows/detect-version-bump.yaml
@@ -9,7 +9,6 @@ jobs:
   check:
     name: Check for pure version bump
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
@@ -19,31 +18,41 @@ jobs:
       - id: check
         # Only skip CI when ALL of the following hold, so a "bump version" commit
         # message can never be used to smuggle in unrelated changes:
+        #  - the triggering event is a push (not a PR, dispatch, etc.)
         #  - the push is exactly one commit
         #  - that commit's message is exactly "bump version"
         #  - the commit touches only pyproject.toml and/or uv.lock
         #  - every changed line in those files is a `version = "X.Y.Z"` line
+        #
+        # Deliberately no job-level `if:` gating this on event_name == 'push' -
+        # GitHub Actions skips downstream `needs:` jobs whenever an upstream job's
+        # own conclusion is "skipped", regardless of the downstream job's `if:`
+        # expression. That would skip build/test on every pull_request run, not
+        # just version-bump pushes. This job must always complete successfully;
+        # the push-only logic lives entirely inside this step instead.
         run: |
           skip=false
-          commit_count=$(echo '${{ toJson(github.event.commits) }}' | jq 'length')
-          msg=$(git log -1 --format=%B HEAD | sed -e 's/[[:space:]]*$//')
-          if [[ "$commit_count" == "1" ]] && [[ "$msg" =~ ^[Bb]ump[[:space:]]version$ ]] && git rev-parse HEAD~1 >/dev/null 2>&1; then
-            files=$(git diff --name-only HEAD~1 HEAD)
-            is_pure=true
-            while IFS= read -r f; do
-              [[ -z "$f" ]] && continue
-              if [[ "$f" != "pyproject.toml" && "$f" != "uv.lock" ]]; then
-                is_pure=false
-              fi
-            done <<< "$files"
-            if [[ "$is_pure" == "true" && -n "$files" ]]; then
-              bad=$(git diff -U0 HEAD~1 HEAD -- pyproject.toml uv.lock \
-                | grep -E '^[+-]' \
-                | grep -vE '^(\+\+\+|---)' \
-                | grep -vE '^[+-]version = "[0-9]+\.[0-9]+\.[0-9]+"$' \
-                || true)
-              if [[ -z "$bad" ]]; then
-                skip=true
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            commit_count=$(echo '${{ toJson(github.event.commits) }}' | jq 'if type=="array" then length else 0 end')
+            msg=$(git log -1 --format=%B HEAD | sed -e 's/[[:space:]]*$//')
+            if [[ "$commit_count" == "1" ]] && [[ "$msg" =~ ^[Bb]ump[[:space:]]version$ ]] && git rev-parse HEAD~1 >/dev/null 2>&1; then
+              files=$(git diff --name-only HEAD~1 HEAD)
+              is_pure=true
+              while IFS= read -r f; do
+                [[ -z "$f" ]] && continue
+                if [[ "$f" != "pyproject.toml" && "$f" != "uv.lock" ]]; then
+                  is_pure=false
+                fi
+              done <<< "$files"
+              if [[ "$is_pure" == "true" && -n "$files" ]]; then
+                bad=$(git diff -U0 HEAD~1 HEAD -- pyproject.toml uv.lock \
+                  | grep -E '^[+-]' \
+                  | grep -vE '^(\+\+\+|---)' \
+                  | grep -vE '^[+-]version = "[0-9]+\.[0-9]+\.[0-9]+"$' \
+                  || true)
+                if [[ -z "$bad" ]]; then
+                  skip=true
+                fi
               fi
             fi
           fi

--- a/.github/workflows/test-mobile.yaml
+++ b/.github/workflows/test-mobile.yaml
@@ -14,8 +14,12 @@ defaults:
     shell: bash
     working-directory: ./mobile
 jobs:
+  detect-version-bump:
+    uses: ./.github/workflows/detect-version-bump.yaml
   test:
     name: Mobile tests
+    needs: detect-version-bump
+    if: needs.detect-version-bump.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -14,8 +14,12 @@ defaults:
     shell: bash
     working-directory: ./ui
 jobs:
+  detect-version-bump:
+    uses: ./.github/workflows/detect-version-bump.yaml
   test:
     name: UI tests
+    needs: detect-version-bump
+    if: needs.detect-version-bump.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,11 @@ defaults:
   run:
     shell: bash
 jobs:
+  detect-version-bump:
+    uses: ./.github/workflows/detect-version-bump.yaml
   build:
+    needs: detect-version-bump
+    if: needs.detect-version-bump.outputs.skip != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -59,11 +63,15 @@ jobs:
   required-checks:
     name: Required checks
     runs-on: ubuntu-latest
-    needs: build
+    needs: [detect-version-bump, build]
     if: always()
     steps:
       - name: Check build result
         run: |
+          if [[ "${{ needs.detect-version-bump.outputs.skip }}" == "true" ]]; then
+            echo "Skipping: version-only bump commit"
+            exit 0
+          fi
           if [[ "${{ needs.build.result }}" != "success" ]]; then
             echo "build job did not succeed: ${{ needs.build.result }}"
             exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezbeq"
-version = "2.11.9"
+version = "2.11.10"
 description = "A webapp which can send beqcatalogue filters to a DSP device"
 authors = [
     { name = "3ll3d00d", email = "mattkhan+ezbeq@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ wheels = [
 
 [[package]]
 name = "ezbeq"
-version = "2.11.9"
+version = "2.11.10"
 source = { editable = "." }
 dependencies = [
     { name = "autobahn", extra = ["twisted"] },


### PR DESCRIPTION
## Summary
- Add a `detect-version-bump` reusable workflow that verifies a push is a single commit, titled exactly "bump version", touching only the version fields in `pyproject.toml`/`uv.lock` — any other change in the diff forces the full suite to run.
- Wire it into `test.yaml`, `test-ui.yaml`, and `test-mobile.yaml` so their build/test jobs (and `test.yaml`'s `required-checks` job) skip rather than fail when it reports a match.

## Test plan
- [ ] Confirm workflows parse (YAML validated locally with `yaml.safe_load`)
- [ ] Push a genuine `bump version` commit and confirm checks show as skipped
- [ ] Push a commit titled `bump version` that also touches other files and confirm checks still run in full