### PR TITLE
ci: gate coverage-regression checks on changed paths, not raw Codecov contexts

### DIFF
--- a/.github/workflows/test-mobile.yaml
+++ b/.github/workflows/test-mobile.yaml
@@ -54,6 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-version-bump, detect-changed-paths, test-run]
     if: always()
+    # statuses:read lets the coverage-gate step below poll Codecov's commit status via the API.
+    permissions:
+      statuses: read
     steps:
       # Overrides the workflow-level `defaults.run.working-directory: ./mobile` - this job never
       # checks out the repo (it only inspects other jobs' needs context), so that directory doesn't
@@ -79,5 +82,31 @@ jobs:
           fi
           if [[ "${{ needs.test-run.result }}" != "success" ]]; then
             echo "test-run job did not succeed: ${{ needs.test-run.result }}"
+            exit 1
+          fi
+      - name: Wait for Codecov coverage-regression result
+        # See test.yaml's "Required checks" job for why this lives here instead of requiring the
+        # raw `codecov/project/mobile` status context directly in branch protection.
+        if: needs.detect-version-bump.outputs.skip != 'true' && needs.detect-changed-paths.outputs.mobile == 'true'
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          context="codecov/project/mobile"
+          deadline=$((SECONDS + 900))
+          state=""
+          while (( SECONDS < deadline )); do
+            state=$(gh api "repos/${{ github.repository }}/commits/${sha}/status" \
+              --jq ".statuses[] | select(.context==\"${context}\") | .state" 2>/dev/null | head -1)
+            echo "t+${SECONDS}s: ${context} = ${state:-<not posted yet>}"
+            case "$state" in
+              success) break ;;
+              error|failure) echo "Codecov reported '${state}' for ${context}"; exit 1 ;;
+            esac
+            sleep 30
+          done
+          if [[ "$state" != "success" ]]; then
+            echo "Timed out after 900s waiting for ${context} - Codecov never reported a result"
             exit 1
           fi

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -52,6 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-version-bump, detect-changed-paths, test-run]
     if: always()
+    # statuses:read lets the coverage-gate step below poll Codecov's commit status via the API.
+    permissions:
+      statuses: read
     steps:
       # Overrides the workflow-level `defaults.run.working-directory: ./ui` - this job never checks
       # out the repo (it only inspects other jobs' needs context), so that directory doesn't exist
@@ -77,5 +80,31 @@ jobs:
           fi
           if [[ "${{ needs.test-run.result }}" != "success" ]]; then
             echo "test-run job did not succeed: ${{ needs.test-run.result }}"
+            exit 1
+          fi
+      - name: Wait for Codecov coverage-regression result
+        # See test.yaml's "Required checks" job for why this lives here instead of requiring the
+        # raw `codecov/project/ui` status context directly in branch protection.
+        if: needs.detect-version-bump.outputs.skip != 'true' && needs.detect-changed-paths.outputs.ui == 'true'
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          context="codecov/project/ui"
+          deadline=$((SECONDS + 900))
+          state=""
+          while (( SECONDS < deadline )); do
+            state=$(gh api "repos/${{ github.repository }}/commits/${sha}/status" \
+              --jq ".statuses[] | select(.context==\"${context}\") | .state" 2>/dev/null | head -1)
+            echo "t+${SECONDS}s: ${context} = ${state:-<not posted yet>}"
+            case "$state" in
+              success) break ;;
+              error|failure) echo "Codecov reported '${state}' for ${context}"; exit 1 ;;
+            esac
+            sleep 30
+          done
+          if [[ "$state" != "success" ]]; then
+            echo "Timed out after 900s waiting for ${context} - Codecov never reported a result"
             exit 1
           fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-version-bump, detect-changed-paths, build]
     if: always()
+    # statuses:read lets the coverage-gate step below poll Codecov's commit status via the API.
+    permissions:
+      statuses: read
     steps:
       - name: Check build result
         # Check the gating jobs' own result before trusting their outputs - if either crashed
@@ -91,5 +94,35 @@ jobs:
           fi
           if [[ "${{ needs.build.result }}" != "success" ]]; then
             echo "build job did not succeed: ${{ needs.build.result }}"
+            exit 1
+          fi
+      - name: Wait for Codecov coverage-regression result
+        # Only reached when python-relevant paths changed and build succeeded (the checks above
+        # already exited 0/1 for every other case) - so unlike the raw `codecov/project/python`
+        # status context (which was required directly in branch protection and simply never posts
+        # for a commit that never uploads, permanently blocking merge - see AGENTS.md's "Before
+        # pushing" item on wrapper jobs for the identical problem with build/test-run), this step
+        # only ever waits when an upload was actually expected. Coarse heartbeat poll bounded by a
+        # timeout, same pattern as the "waiting for PR checks" guidance in AGENTS.md.
+        if: needs.detect-version-bump.outputs.skip != 'true' && needs.detect-changed-paths.outputs.python == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          context="codecov/project/python"
+          deadline=$((SECONDS + 900))
+          state=""
+          while (( SECONDS < deadline )); do
+            state=$(gh api "repos/${{ github.repository }}/commits/${sha}/status" \
+              --jq ".statuses[] | select(.context==\"${context}\") | .state" 2>/dev/null | head -1)
+            echo "t+${SECONDS}s: ${context} = ${state:-<not posted yet>}"
+            case "$state" in
+              success) break ;;
+              error|failure) echo "Codecov reported '${state}' for ${context}"; exit 1 ;;
+            esac
+            sleep 30
+          done
+          if [[ "$state" != "success" ]]; then
+            echo "Timed out after 900s waiting for ${context} - Codecov never reported a result"
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,9 @@ above it, so the wrapper still resolves immediately.
 `enforce_admins` on): a pull request is required to merge into `main` — direct pushes are rejected,
 full stop, no bypass — and it can't merge until `Required checks` (Python), `UI tests`, and `Mobile
 tests` are all green — each of which now embeds its own subtree's coverage-regression gate (see
-above), so no separate Codecov contexts need to be required. No required approving review
+above), so no separate Codecov contexts need to be required **once branch protection's required
+status checks list is updated to drop the three raw `codecov/project/*` entries — a manual repo-
+admin step, not yet done as of this change**. No required approving review
 count is set (solo-maintainer repo — GitHub won't let you approve your own PR, so requiring a review
 would deadlock every merge); the PR requirement exists to guarantee checks have actually run against
 the merge commit, not to gate on a second pair of eyes. See "Before pushing" below — passing CI is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,14 +110,25 @@ gating job would turn a CI infrastructure failure into a false green rather than
 Coverage regressions are gated by `codecov.yml`: each sub-project uploads under its own flag
 (`python`, `ui`, `mobile`) and Codecov's per-flag `project` status fails a commit/PR if that flag's
 overall coverage drops versus its merge base (`target: auto`, `threshold: 0%` — zero tolerance,
-`patch` coverage is intentionally not gated). `carryforward: true` on each flag means a commit that
-genuinely doesn't touch a subtree reuses that flag's last known coverage rather than showing as
-missing.
+`patch` coverage is intentionally not gated). `carryforward: true` on each flag exists so Codecov's
+own coverage *trend* for that flag doesn't show a gap on a commit that didn't touch its subtree —
+but it is **not** a substitute for a CI trigger: Codecov never posts a `codecov/project/<flag>`
+status for a commit at all unless something uploads to it (or a Checks-API webhook it's watching
+fires), which never happens for a commit that legitimately skipped that flag's `build`/`test-run`
+job. The three `codecov/project/*` contexts are therefore **not** required directly in branch
+protection (a PR touching none of `ezbeq/`, `ui/src/`, `mobile/src/` would otherwise sit
+`mergeStateStatus: BLOCKED` forever, no status ever arriving to satisfy them — this happened for
+real on PR #118). Instead, `Required checks`/`UI tests`/`Mobile tests` poll the matching Codecov
+status themselves, but only when `detect-changed-paths` says the relevant subtree changed —
+coarse heartbeat poll bounded by a 900s timeout, same shape as the "waiting for PR checks" guidance
+below. When the subtree didn't change, that step is skipped just like the `build`/`test-run` check
+above it, so the wrapper still resolves immediately.
 
 **`main` is a real gate, enforced for everyone including repo admins** (branch protection has
 `enforce_admins` on): a pull request is required to merge into `main` — direct pushes are rejected,
-full stop, no bypass — and it can't merge until `Required checks` (Python), `UI tests`, `Mobile
-tests`, and the three Codecov project-coverage checks are all green. No required approving review
+full stop, no bypass — and it can't merge until `Required checks` (Python), `UI tests`, and `Mobile
+tests` are all green — each of which now embeds its own subtree's coverage-regression gate (see
+above), so no separate Codecov contexts need to be required. No required approving review
 count is set (solo-maintainer repo — GitHub won't let you approve your own PR, so requiring a review
 would deadlock every merge); the PR requirement exists to guarantee checks have actually run against
 the merge commit, not to gate on a second pair of eyes. See "Before pushing" below — passing CI is


### PR DESCRIPTION
## Summary
- The three `codecov/project/{python,ui,mobile}` status contexts were required directly in branch protection, but Codecov only posts them for a commit that actually uploaded coverage for that flag. A PR touching none of `ezbeq/`, `ui/src/`, `mobile/src/` never triggers an upload, so those contexts never post and the PR sits `mergeStateStatus: BLOCKED` forever — reproduced on #118, a pure `AGENTS.md` docs change.
- `carryforward: true` in `codecov.yml` only smooths Codecov's own coverage *trend* display; it does not substitute for the missing CI trigger, contrary to what `AGENTS.md` previously implied.
- Fix applies the same wrapper-job pattern this repo already uses to make `Required checks`/`UI tests`/`Mobile tests` skip-safe for `build`/`test-run` (see `detect-changed-paths.yaml`'s own header comment for the original version of this problem). Each wrapper now polls its matching `codecov/project/<flag>` status only when `detect-changed-paths` says that subtree changed, using a bounded heartbeat poll (900s timeout, same shape as the check-polling guidance in `AGENTS.md`). When the subtree didn't change, the step is skipped, exactly like the existing `build`/`test-run` check.
- Updated `AGENTS.md`'s CI/CD section to describe the corrected architecture and the carryforward caveat.

## Follow-up required (not in this PR)
Branch protection's required status checks list still includes the three raw `codecov/project/*` contexts. Those need to be **removed** from the required list (repo admin action via Settings → Branches, or `gh api`) for this fix to actually unblock docs-only PRs — otherwise both the old (permanently-missing) and new (wrapper-embedded) gates are required simultaneously, and the old one still blocks forever.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all three edited workflow files — parses cleanly.
- [ ] After merge, verify on a real docs-only PR that `Required checks`/`UI tests`/`Mobile tests` resolve immediately (skip) with no Codecov wait.
- [ ] After merge, verify on a real code-touching PR that the new "Wait for Codecov coverage-regression result" step correctly waits for and reflects Codecov's actual status.